### PR TITLE
Updated GPT2 and Roberta decoding to allow for invalid byte sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ![License](https://img.shields.io/crates/l/rust_tokenizers.svg)
 
 Rust-tokenizer is a drop-in replacement for the tokenization methods from the [Transformers library](https://github.com/huggingface/transformers)
-It includes a broad range of tokenizers for state-of-the-art transformers architectures, including:
+These tokenizers are used in the [rust-bert](https://github.com/guillaume-be/rust-bert) crate.
+A broad range of tokenizers for state-of-the-art transformers architectures is included, including:
 - BERT
 - DistilBERT
 - RoBERTa

--- a/main/Cargo.lock
+++ b/main/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "rust_tokenizers"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_tokenizers"
-version = "2.0.4"
+version = "2.0.5"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 description = "High performance tokenizers for Rust"

--- a/main/src/preprocessing/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/preprocessing/tokenizer/gpt2_tokenizer.rs
@@ -116,8 +116,7 @@ impl Tokenizer<Gpt2Vocab> for Gpt2Tokenizer {
             .chars()
             .map(|character| UNICODE_TO_BYTES.get(&character).unwrap().clone())
             .collect_vec();
-
-        String::from_utf8(tokens).unwrap()
+        String::from_utf8_lossy(&tokens).to_string()
     }
 }
 

--- a/main/src/preprocessing/tokenizer/roberta_tokenizer.rs
+++ b/main/src/preprocessing/tokenizer/roberta_tokenizer.rs
@@ -153,7 +153,7 @@ impl Tokenizer<RobertaVocab> for RobertaTokenizer {
             .map(|character| UNICODE_TO_BYTES.get(&character).unwrap().clone())
             .collect_vec();
 
-        String::from_utf8(tokens).unwrap()
+        String::from_utf8_lossy(&tokens).to_string()
     }
 }
 

--- a/python-bindings/Cargo.lock
+++ b/python-bindings/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "rust_tokenizers"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "csv",
  "itertools",


### PR DESCRIPTION
- Switch to lossy decoding for invalid byte sequences for GPT2 and Roberta tokenizers