### PR TITLE
Addition of methods to find continuation tokens

### DIFF
--- a/main/src/preprocessing/tokenizer/base_tokenizer.rs
+++ b/main/src/preprocessing/tokenizer/base_tokenizer.rs
@@ -114,6 +114,10 @@ pub trait Tokenizer<T: Vocab> {
         }
     }
 
+    fn is_continuation_token(&self, _token: &str) -> bool {
+        false
+    }
+
     fn convert_tokens_to_string(&self, tokens: Vec<String>) -> String {
         tokens.join(" ")
     }

--- a/main/src/preprocessing/tokenizer/bert_tokenizer.rs
+++ b/main/src/preprocessing/tokenizer/bert_tokenizer.rs
@@ -77,6 +77,10 @@ impl Tokenizer<BertVocab> for BertTokenizer {
         (output, token_segment_ids, special_tokens_mask)
     }
 
+    fn is_continuation_token(&self, token: &str) -> bool {
+        token.starts_with("##")
+    }
+
     fn convert_tokens_to_string(&self, tokens: Vec<String>) -> String {
         tokens.join(" ").replace(" ##", "").trim().to_owned()
     }
@@ -319,5 +323,39 @@ mod tests {
         }
         assert_eq!(Tokenizer::decode_list(&bert_tokenizer, source_ids.clone(), skip_special_tokens, clean_up_tokenization_spaces), expected_results);
         assert_eq!(MultiThreadedTokenizer::decode_list(&bert_tokenizer, source_ids.clone(), skip_special_tokens, clean_up_tokenization_spaces), expected_results);
+    }
+
+    #[test]
+    fn test_is_continuation_token() {
+//        Given
+        let vocab = Arc::new(generate_test_vocab());
+        let bert_tokenizer: BertTokenizer = BertTokenizer::from_existing_vocab(vocab, true);
+        let test_tuples = [
+            (
+                "Hello",
+                false,
+            ),
+            (
+                "Una",
+                false,
+            ),
+            (
+                "##ffa",
+                true,
+            ),
+            (
+                "##ble",
+                true,
+            ),
+            (
+                "",
+                false,
+            )
+        ];
+
+//        When & Then
+        for (source_ids, expected_result) in test_tuples.iter() {
+            assert_eq!(bert_tokenizer.is_continuation_token(source_ids), *expected_result);
+        }
     }
 }

--- a/main/src/preprocessing/tokenizer/roberta_tokenizer.rs
+++ b/main/src/preprocessing/tokenizer/roberta_tokenizer.rs
@@ -143,6 +143,19 @@ impl Tokenizer<RobertaVocab> for RobertaTokenizer {
         (output, token_segment_ids, special_tokens_mask)
     }
 
+    fn is_continuation_token(&self, token: &str) -> bool {
+        if token.is_empty() {
+            false
+        } else if token.starts_with("Ġ") {
+            false
+        } else {
+            match token.find(|c: char| { !c.is_alphabetic() }) {
+                Some(0) => false,
+                _ => true,
+            }
+        }
+    }
+
     fn convert_tokens_to_string(&self, tokens: Vec<String>) -> String {
         let tokens = tokens
             .iter()
@@ -333,5 +346,40 @@ mod tests {
                        *expected_result);
         }
         assert_eq!(Tokenizer::decode_list(&roberta_tokenizer, source_ids.clone(), skip_special_tokens, clean_up_tokenization_spaces), expected_results);
+    }
+
+    #[test]
+    fn test_is_continuation_token() {
+//        Given
+        let vocab = Rc::new(generate_test_vocab());
+        let merges = Rc::new(generate_test_merges());
+        let roberta_tokenizer: RobertaTokenizer = RobertaTokenizer::from_existing_vocab_and_merges(vocab, merges, true);
+        let test_tuples = [
+            (
+                "ĠHello",
+                false,
+            ),
+            (
+                "ĠUna",
+                false,
+            ),
+            (
+                "ffa",
+                true,
+            ),
+            (
+                "ble",
+                true,
+            ),
+            (
+                "",
+                false,
+            )
+        ];
+
+//        When & Then
+        for (source_ids, expected_result) in test_tuples.iter() {
+            assert_eq!(roberta_tokenizer.is_continuation_token(source_ids), *expected_result);
+        }
     }
 }


### PR DESCRIPTION
@proycon for information, addition of utilities at the tokenizer level to identify continuation tokens. Behaviour is a bit different for OpenAI GPT and CTRL because they mark *leading* elements of a multi-token word, rather than continuation tokens.

I have reused your code for GPT2 and RoBERTa as in this case the marking is not explicit. I think your work-around should actually cover most of the cases, except for the first word of a sentence if no leading space was added.