### PR TITLE
Fixed lookahead split allowing for separators with UTF-8 length > 1

### DIFF
--- a/main/Cargo.lock
+++ b/main/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "rust_tokenizers"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_tokenizers"
-version = "3.1.2"
+version = "3.1.3"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 description = "High performance tokenizers for Rust"

--- a/main/src/preprocessing/tokenizer/tokenization_utils.rs
+++ b/main/src/preprocessing/tokenizer/tokenization_utils.rs
@@ -269,7 +269,10 @@ pub fn split_on_regex_with_lookahead<'a>(token: TokenRef<'a>, pattern_lookahead:
         let mut i: usize = 0;
         let mut end_byte: usize;
         for hit in pattern_lookahead.find_iter(token.text) {
-            end_byte = hit.end() - 1 - hit.as_str().chars().last().unwrap().len_utf8();
+            let mut hit_chars = hit.as_str().chars().rev();
+            let start = hit_chars.next().unwrap();
+            let sep = hit_chars.next().unwrap();
+            end_byte = hit.end() - sep.len_utf8() - start.len_utf8();
             splits.push(&token.text[i..end_byte]);
             i = end_byte;
         }


### PR DESCRIPTION
fix for https://github.com/guillaume-be/rust-tokenizers/issues/30, allowing separators with a UTF-8 length greater than 1 such as `\u{a0}`