### PR TITLE
Multithreaded bpe

### DIFF
--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -31,7 +31,6 @@ use crate::{Mask, Offset, OffsetSize, Token, TokenRef};
 /// - (optional) lower casing
 /// - (optional) accent stripping
 /// - SentencePiece decomposition
-#[derive(Debug, Clone)]
 pub struct AlbertTokenizer {
     model: SentencePieceModel,
     vocab: AlbertVocab,

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -1462,7 +1462,6 @@ where
 /// - (optional) accent stripping
 ///
 /// This tokenizer is used as a pre-tokenizer step in the BERT and GPT tokenizers.
-#[derive(Debug, Clone)]
 pub struct BaseTokenizer<T: Vocab> {
     vocab: Arc<T>,
     lower_case: bool,

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 /// BERT tokenizer performing:
 /// - BaseTokenizer tokenization (see `BaseTokenizer` for more details)
 /// - WordPiece tokenization
-#[derive(Debug, Clone)]
 pub struct BertTokenizer {
     vocab: Arc<BertVocab>,
     base_tokenizer: BaseTokenizer<BertVocab>,

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -22,8 +22,8 @@ use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{OpenAiGptVocab, Vocab};
 use crate::{Mask, Token, TokenRef};
 use regex::Regex;
-use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::RwLock;
 
 /// # CTRL tokenizer
 /// CTRL tokenizer performing:
@@ -31,7 +31,6 @@ use std::collections::HashMap;
 /// - whitespace splitting
 /// - (optional) lower casing
 /// - BPE tokenization
-#[derive(Debug, Clone)]
 pub struct CtrlTokenizer {
     vocab: OpenAiGptVocab,
     bpe_ranks: BpePairVocab,
@@ -64,7 +63,7 @@ impl CtrlTokenizer {
     ) -> Result<CtrlTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file(vocab_path)?;
         let bpe_ranks = BpePairVocab::from_file(merges_path)?;
-        let cache = RefCell::new(HashMap::new());
+        let cache = RwLock::new(HashMap::new());
         let regex_pattern = Regex::new(r"\S+\n?").unwrap();
         Ok(CtrlTokenizer {
             vocab,
@@ -98,7 +97,7 @@ impl CtrlTokenizer {
         merges: BpePairVocab,
         lower_case: bool,
     ) -> CtrlTokenizer {
-        let cache = RefCell::new(HashMap::new());
+        let cache = RwLock::new(HashMap::new());
         let regex_pattern = Regex::new(r"\S+\n?").unwrap();
         CtrlTokenizer {
             vocab,

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -17,7 +17,7 @@ use crate::tokenizer::tokenization_utils::{
     ctrl_bpe, fix_mask, lowercase, split_on_bpe_pairs, split_on_regex, split_on_special_tokens,
     BpeCache,
 };
-use crate::tokenizer::Tokenizer;
+use crate::tokenizer::{MultiThreadedTokenizer, Tokenizer};
 use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{OpenAiGptVocab, Vocab};
 use crate::{Mask, Token, TokenRef};
@@ -148,6 +148,8 @@ impl Tokenizer<OpenAiGptVocab> for CtrlTokenizer {
     }
 }
 
+impl MultiThreadedTokenizer<OpenAiGptVocab> for CtrlTokenizer {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,7 +235,7 @@ mod tests {
         }
 
         assert_eq!(
-            ctrl_tokenizer.tokenize_list(&source_texts),
+            MultiThreadedTokenizer::tokenize_list(&ctrl_tokenizer, &source_texts),
             expected_results
         );
     }
@@ -266,7 +268,7 @@ mod tests {
         }
 
         assert_eq!(
-            ctrl_tokenizer.tokenize_list(&source_texts),
+            MultiThreadedTokenizer::tokenize_list(&ctrl_tokenizer, &source_texts),
             expected_results
         );
     }
@@ -389,7 +391,13 @@ mod tests {
             );
         }
         assert_eq!(
-            ctrl_tokenizer.encode_list(&source_texts, 128, &truncation_strategy, 0),
+            MultiThreadedTokenizer::encode_list(
+                &ctrl_tokenizer,
+                &source_texts,
+                128,
+                &truncation_strategy,
+                0
+            ),
             expected_results
         );
     }

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -29,7 +29,6 @@ use regex::Regex;
 /// - NFKC decomposition
 /// - (optional) lower casing
 /// - SentencePiece decomposition
-#[derive(Debug, Clone)]
 pub struct MarianTokenizer {
     model: SentencePieceModel,
     vocab: MarianVocab,

--- a/main/src/tokenizer/mod.rs
+++ b/main/src/tokenizer/mod.rs
@@ -30,8 +30,7 @@
 //!     - T5
 //!     - Marian
 //!
-//! WordPiece tokenizers and SentencePiece tokenizers support multithreading (via the `MultiThreadedTokenizer` trait).
-//! Byte-Pair Encoding tokenizers do not support multithreading and instead rely on an internal cache for improving decoding efficiency.
+//! All tokenizers are `Send`, `Sync` and support multi-threaded tokenization and encoding.
 
 mod albert_tokenizer;
 pub(crate) mod base_tokenizer;

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -14,7 +14,7 @@
 
 use crate::error::TokenizerError;
 use crate::tokenizer::tokenization_utils::{openai_gpt_bpe, split_on_bpe_pairs, BpeCache};
-use crate::tokenizer::{BaseTokenizer, Tokenizer};
+use crate::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, Tokenizer};
 use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{OpenAiGptVocab, Vocab};
 use crate::{Mask, Token, TokenRef};
@@ -137,6 +137,8 @@ impl Tokenizer<OpenAiGptVocab> for OpenAiGptTokenizer {
     }
 }
 
+impl MultiThreadedTokenizer<OpenAiGptVocab> for OpenAiGptTokenizer {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,7 +225,7 @@ mod tests {
         }
 
         assert_eq!(
-            openai_gpt_tokenizer.tokenize_list(&source_texts),
+            MultiThreadedTokenizer::tokenize_list(&openai_gpt_tokenizer, &source_texts),
             expected_results
         );
     }
@@ -253,7 +255,7 @@ mod tests {
         }
 
         assert_eq!(
-            openai_gpt_tokenizer.tokenize_list(&source_texts),
+            MultiThreadedTokenizer::tokenize_list(&openai_gpt_tokenizer, &source_texts),
             expected_results
         );
     }
@@ -323,7 +325,13 @@ mod tests {
             );
         }
         assert_eq!(
-            openai_gpt_tokenizer.encode_list(&source_texts, 128, &truncation_strategy, 0),
+            MultiThreadedTokenizer::encode_list(
+                &openai_gpt_tokenizer,
+                &source_texts,
+                128,
+                &truncation_strategy,
+                0
+            ),
             expected_results
         );
     }

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -18,15 +18,13 @@ use crate::tokenizer::{BaseTokenizer, Tokenizer};
 use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{OpenAiGptVocab, Vocab};
 use crate::{Mask, Token, TokenRef};
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 /// # GPT tokenizer
 /// GPT tokenizer performing:
 /// - BaseTokenizer tokenization (see `BaseTokenizer` for more details)
 /// - BPE tokenization
-#[derive(Debug, Clone)]
 pub struct OpenAiGptTokenizer {
     vocab: Arc<OpenAiGptVocab>,
     base_tokenizer: BaseTokenizer<OpenAiGptVocab>,
@@ -60,7 +58,7 @@ impl OpenAiGptTokenizer {
         let vocab = Arc::new(OpenAiGptVocab::from_file(vocab_path)?);
         let base_tokenizer = BaseTokenizer::from_existing_vocab(vocab.clone(), lower_case, true);
         let bpe_ranks = BpePairVocab::from_file(merges_path)?;
-        let cache = RefCell::new(HashMap::new());
+        let cache = RwLock::new(HashMap::new());
         Ok(OpenAiGptTokenizer {
             vocab,
             base_tokenizer,
@@ -95,7 +93,7 @@ impl OpenAiGptTokenizer {
         lower_case: bool,
     ) -> OpenAiGptTokenizer {
         let base_tokenizer = BaseTokenizer::from_existing_vocab(vocab.clone(), lower_case, true);
-        let cache = RefCell::new(HashMap::new());
+        let cache = RwLock::new(HashMap::new());
         OpenAiGptTokenizer {
             vocab,
             base_tokenizer,

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -27,9 +27,9 @@ use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{RobertaVocab, Vocab};
 use itertools::Itertools;
 use regex::Regex;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::iter::Iterator;
+use std::sync::RwLock;
 
 /// # RoBERTa tokenizer
 /// RoBERTa tokenizer performing:
@@ -37,7 +37,6 @@ use std::iter::Iterator;
 /// - whitespace splitting
 /// - (optional) lower casing
 /// - BPE tokenization
-#[derive(Debug, Clone)]
 pub struct RobertaTokenizer {
     vocab: RobertaVocab,
     bpe_ranks: BpePairVocab,
@@ -79,7 +78,7 @@ impl RobertaTokenizer {
     ) -> Result<RobertaTokenizer, TokenizerError> {
         let vocab = RobertaVocab::from_file(vocab_path)?;
         let bpe_ranks = BpePairVocab::from_file(merges_path)?;
-        let cache = RefCell::new(HashMap::new());
+        let cache = RwLock::new(HashMap::new());
         let pattern_lookahead = Regex::new(r"\s+\S").unwrap();
         let pattern_tokenization =
             Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+")
@@ -125,7 +124,7 @@ impl RobertaTokenizer {
         lower_case: bool,
         add_prefix_space: bool,
     ) -> RobertaTokenizer {
-        let cache = RefCell::new(HashMap::new());
+        let cache = RwLock::new(HashMap::new());
         let pattern_lookahead = Regex::new(r"\s+\S").unwrap();
         let pattern_tokenization =
             Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+")

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -23,6 +23,7 @@ use crate::tokenizer::tokenization_utils::{
     split_on_special_tokens,
 };
 use crate::tokenizer::tokenization_utils::{lowercase, BpeCache};
+use crate::tokenizer::MultiThreadedTokenizer;
 use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{RobertaVocab, Vocab};
 use itertools::Itertools;
@@ -256,6 +257,8 @@ impl Tokenizer<RobertaVocab> for RobertaTokenizer {
     }
 }
 
+impl MultiThreadedTokenizer<RobertaVocab> for RobertaTokenizer {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,7 +386,7 @@ mod tests {
         }
 
         assert_eq!(
-            roberta_tokenizer.tokenize_list(&source_texts),
+            MultiThreadedTokenizer::tokenize_list(&roberta_tokenizer, &source_texts),
             expected_results
         );
     }
@@ -472,7 +475,7 @@ mod tests {
         }
 
         assert_eq!(
-            roberta_tokenizer.tokenize_list(&source_texts),
+            MultiThreadedTokenizer::tokenize_list(&roberta_tokenizer, &source_texts),
             expected_results
         );
     }
@@ -570,7 +573,13 @@ mod tests {
             );
         }
         assert_eq!(
-            roberta_tokenizer.encode_list(&source_texts, 128, &truncation_strategy, 0),
+            MultiThreadedTokenizer::encode_list(
+                &roberta_tokenizer,
+                &source_texts,
+                128,
+                &truncation_strategy,
+                0
+            ),
             expected_results
         );
     }

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -23,7 +23,6 @@ use crate::vocab::{SentencePieceModel, SentencePieceVocab, Vocab};
 /// - NFKC decomposition
 /// - (optional) lower casing
 /// - SentencePiece decomposition
-#[derive(Debug, Clone)]
 pub struct SentencePieceTokenizer {
     model: SentencePieceModel,
     vocab: SentencePieceVocab,

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -25,7 +25,6 @@ use crate::{Mask, Token, TokenRef};
 /// - NFKC decomposition
 /// - (optional) lower casing
 /// - SentencePiece decomposition
-#[derive(Debug, Clone)]
 pub struct T5Tokenizer {
     model: SentencePieceModel,
     vocab: T5Vocab,

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -27,7 +27,6 @@ use crate::vocab::{SentencePieceModel, Vocab, XLMRobertaVocab};
 /// - NFKC decomposition
 /// - (optional) lower casing
 /// - SentencePiece decomposition
-#[derive(Debug, Clone)]
 pub struct XLMRobertaTokenizer {
     model: SentencePieceModel,
     vocab: XLMRobertaVocab,

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -28,7 +28,6 @@ use crate::{Mask, Offset, OffsetSize, Token, TokenRef};
 /// - (optional) lower casing
 /// - (optional) accents stripping
 /// - SentencePiece decomposition
-#[derive(Debug, Clone)]
 pub struct XLNetTokenizer {
     model: SentencePieceModel,
     vocab: XLNetVocab,

--- a/python-bindings/src/lib.rs
+++ b/python-bindings/src/lib.rs
@@ -475,6 +475,8 @@ impl PyTokenizer<Gpt2Tokenizer, Gpt2Vocab> for PyGpt2Tokenizer {
     }
 }
 
+impl PyMultiThreadTokenizer<Gpt2Tokenizer, Gpt2Vocab> for PyGpt2Tokenizer {}
+
 #[pymethods]
 impl PyGpt2Tokenizer {
     #[new]
@@ -494,7 +496,7 @@ impl PyGpt2Tokenizer {
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyTokenizer<Gpt2Tokenizer, Gpt2Vocab>>::tokenize_list(&self, text_list)
+        <Self as PyMultiThreadTokenizer<Gpt2Tokenizer, Gpt2Vocab>>::tokenize_list(&self, text_list)
     }
 
     fn encode(
@@ -538,7 +540,7 @@ impl PyGpt2Tokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<Gpt2Tokenizer, Gpt2Vocab>>::encode_list(
+        <Self as PyMultiThreadTokenizer<Gpt2Tokenizer, Gpt2Vocab>>::encode_list(
             &self,
             text_list,
             max_len,
@@ -554,7 +556,7 @@ impl PyGpt2Tokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<Gpt2Tokenizer, Gpt2Vocab>>::encode_pair_list(
+        <Self as PyMultiThreadTokenizer<Gpt2Tokenizer, Gpt2Vocab>>::encode_pair_list(
             &self,
             text_list,
             max_len,

--- a/python-bindings/src/lib.rs
+++ b/python-bindings/src/lib.rs
@@ -375,6 +375,8 @@ impl PyTokenizer<CtrlTokenizer, OpenAiGptVocab> for PyCtrlTokenizer {
     }
 }
 
+impl PyMultiThreadTokenizer<CtrlTokenizer, OpenAiGptVocab> for PyCtrlTokenizer {}
+
 #[pymethods]
 impl PyCtrlTokenizer {
     #[new]
@@ -394,7 +396,9 @@ impl PyCtrlTokenizer {
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyTokenizer<CtrlTokenizer, OpenAiGptVocab>>::tokenize_list(&self, text_list)
+        <Self as PyMultiThreadTokenizer<CtrlTokenizer, OpenAiGptVocab>>::tokenize_list(
+            &self, text_list,
+        )
     }
 
     fn encode(
@@ -438,7 +442,7 @@ impl PyCtrlTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<CtrlTokenizer, OpenAiGptVocab>>::encode_list(
+        <Self as PyMultiThreadTokenizer<CtrlTokenizer, OpenAiGptVocab>>::encode_list(
             &self,
             text_list,
             max_len,
@@ -454,7 +458,7 @@ impl PyCtrlTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<CtrlTokenizer, OpenAiGptVocab>>::encode_pair_list(
+        <Self as PyMultiThreadTokenizer<CtrlTokenizer, OpenAiGptVocab>>::encode_pair_list(
             &self,
             text_list,
             max_len,
@@ -577,6 +581,8 @@ impl PyTokenizer<RobertaTokenizer, RobertaVocab> for PyRobertaTokenizer {
     }
 }
 
+impl PyMultiThreadTokenizer<RobertaTokenizer, RobertaVocab> for PyRobertaTokenizer {}
+
 #[pymethods]
 impl PyRobertaTokenizer {
     #[new]
@@ -602,7 +608,9 @@ impl PyRobertaTokenizer {
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyTokenizer<RobertaTokenizer, RobertaVocab>>::tokenize_list(&self, text_list)
+        <Self as PyMultiThreadTokenizer<RobertaTokenizer, RobertaVocab>>::tokenize_list(
+            &self, text_list,
+        )
     }
 
     fn encode(
@@ -646,7 +654,7 @@ impl PyRobertaTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<RobertaTokenizer, RobertaVocab>>::encode_list(
+        <Self as PyMultiThreadTokenizer<RobertaTokenizer, RobertaVocab>>::encode_list(
             &self,
             text_list,
             max_len,
@@ -662,7 +670,7 @@ impl PyRobertaTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<RobertaTokenizer, RobertaVocab>>::encode_pair_list(
+        <Self as PyMultiThreadTokenizer<RobertaTokenizer, RobertaVocab>>::encode_pair_list(
             &self,
             text_list,
             max_len,
@@ -683,6 +691,8 @@ impl PyTokenizer<OpenAiGptTokenizer, OpenAiGptVocab> for PyOpenAiGptTokenizer {
     }
 }
 
+impl PyMultiThreadTokenizer<OpenAiGptTokenizer, OpenAiGptVocab> for PyOpenAiGptTokenizer {}
+
 #[pymethods]
 impl PyOpenAiGptTokenizer {
     #[new]
@@ -702,7 +712,9 @@ impl PyOpenAiGptTokenizer {
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyTokenizer<OpenAiGptTokenizer, OpenAiGptVocab>>::tokenize_list(&self, text_list)
+        <Self as PyMultiThreadTokenizer<OpenAiGptTokenizer, OpenAiGptVocab>>::tokenize_list(
+            &self, text_list,
+        )
     }
 
     fn encode(
@@ -746,7 +758,7 @@ impl PyOpenAiGptTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<OpenAiGptTokenizer, OpenAiGptVocab>>::encode_list(
+        <Self as PyMultiThreadTokenizer<OpenAiGptTokenizer, OpenAiGptVocab>>::encode_list(
             &self,
             text_list,
             max_len,
@@ -762,7 +774,7 @@ impl PyOpenAiGptTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyTokenizer<OpenAiGptTokenizer, OpenAiGptVocab>>::encode_pair_list(
+        <Self as PyMultiThreadTokenizer<OpenAiGptTokenizer, OpenAiGptVocab>>::encode_pair_list(
             &self,
             text_list,
             max_len,


### PR DESCRIPTION
- Replaced `RefCell` to `RwLock` for caching mechanism in BPE tokenizers
- All tokenizers now `Send` and `Sync`
- All tokenizers now support multithreading