### PR TITLE
Special token map extension

### DIFF
--- a/main/Cargo.lock
+++ b/main/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "autocfg"
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -337,15 +337,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -442,12 +436,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -467,9 +461,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -585,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl"
@@ -648,11 +642,11 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -691,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -703,14 +697,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -735,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -755,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -770,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64",
  "bytes 1.0.1",
@@ -786,10 +779,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -797,6 +790,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -811,7 +805,7 @@ dependencies = [
  "anyhow",
  "csv",
  "dirs",
- "hashbrown 0.12.0",
+ "hashbrown",
  "itertools",
  "lazy_static",
  "protobuf",
@@ -874,18 +868,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -894,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -939,13 +933,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -964,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1080,10 +1074,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.19"
+name = "unicode-ident"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -1096,12 +1096,6 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -12,23 +12,23 @@ keywords = ["nlp", "machine-learning", "tokenizer"]
 
 [dependencies]
 csv = "1.1.6"
-unicode-normalization = "0.1.19"
-rayon = "1.5.1"
+unicode-normalization = "0.1.22"
+rayon = "1.5.3"
 lazy_static = "1.4.0"
-itertools = "0.10.3"
-serde = {version = "1.0.136", features = ["derive"]}
-serde_json = "1.0.79"
-regex = "1.5.5"
-protobuf = "= 2.27.1"
-hashbrown = "0.12.0"
+itertools = "0.10.5"
+serde = {version = "1.0.145", features = ["derive"]}
+serde_json = "1.0.85"
+regex = "1.6.0"
+protobuf = "2.27.1"
+hashbrown = "0.12.3"
 unicode-normalization-alignments = "0.1.12"
-thiserror = "1.0.30"
+thiserror = "1.0.35"
 
 [dev-dependencies]
 tempfile = "3.3.0"
 dirs = "4.0.0"
-reqwest = {version = "0.11.10", features = ["blocking"]}
-anyhow = "1.0.56"
+reqwest = {version = "0.11.12", features = ["blocking"]}
+anyhow = "1.0.65"
 
 [build-dependencies]
 protobuf-codegen-pure = {version = "2.27.1", optional = true}

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -217,25 +217,9 @@ impl Tokenizer<AlbertVocab> for AlbertTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .cls_token
-                    .as_ref()
-                    .expect("CLS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -251,15 +235,7 @@ impl Tokenizer<AlbertVocab> for AlbertTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -168,7 +168,7 @@ impl AlbertTokenizer {
                     } else {
                         let first_char_length =
                             updated_tokens[0].text.chars().next().unwrap().len_utf8();
-                        updated_tokens[0].text = (&updated_tokens[0].text[first_char_length..])
+                        updated_tokens[0].text = (updated_tokens[0].text[first_char_length..])
                             .parse()
                             .unwrap();
                     }

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -71,6 +71,46 @@ impl AlbertTokenizer {
         })
     }
 
+    /// Create a new instance of a `AlbertTokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
+    /// let strip_accents = false;
+    /// let lower_case = false;
+    /// let tokenizer = AlbertTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<AlbertTokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab =
+            AlbertVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        Ok(AlbertTokenizer {
+            model,
+            vocab,
+            lower_case,
+            strip_accents,
+        })
+    }
+
     /// Create a new instance of a `AlbertTokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -217,9 +217,25 @@ impl Tokenizer<AlbertVocab> for AlbertTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(self.vocab.token_to_id(AlbertVocab::cls_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .cls_token
+                    .as_ref()
+                    .expect("CLS token expected for encoding"),
+            ),
+        );
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(AlbertVocab::sep_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .sep_token
+                    .as_ref()
+                    .expect("SEP token expected for encoding"),
+            ),
+        );
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -235,7 +251,15 @@ impl Tokenizer<AlbertVocab> for AlbertTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(AlbertVocab::sep_value()));
+            output.push(
+                self.vocab.token_to_id(
+                    self.vocab
+                        .special_token_map
+                        .sep_token
+                        .as_ref()
+                        .expect("SEP token expected for encoding"),
+                ),
+            );
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -1456,6 +1456,44 @@ pub struct BaseTokenizer<T: Vocab> {
 
 impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// Create a new instance of a `BaseTokenizer`
+    /// Expects a vocabulary flat-file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the vocabulary file (only used for special character splitting)
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
+    /// use rust_tokenizers::vocab::BaseVocab;
+    /// let strip_accents = false;
+    /// let lower_case = false;
+    /// let tokenizer: BaseTokenizer<BaseVocab> = BaseTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<BaseTokenizer<T>, TokenizerError> {
+        let vocab = T::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        Ok(BaseTokenizer {
+            vocab,
+            lower_case,
+            strip_accents,
+        })
+    }
+
+    /// Create a new instance of a `BaseTokenizer`
     /// Expects a vocabulary flat-file as an input.
     ///
     /// # Parameters

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -312,7 +312,7 @@ impl<'a> ConsolidatableTokens<TokenRef<'a>> for Vec<TokenRef<'a>> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 /// Owned token that references the original text but stores its own string representation.
 pub struct Token {
     /// String representation
@@ -369,7 +369,7 @@ impl Token {
 
 /// # Tokenized Input, ready for processing in language models
 /// This represents the final output of the encoding process (tokenized sentence with encoded values)
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
 pub struct TokenizedInput {
     /// Vector of token IDs
     pub token_ids: Vec<i64>,
@@ -446,7 +446,7 @@ pub struct TokensWithOffsets {
 
 /// # Encoded sequence
 /// Intermediate tokenization steps before addition of special tokens, after encoding
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TokenIdsWithOffsets {
     /// Vector of token IDs
     pub ids: Vec<i64>,

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -1575,7 +1575,7 @@ mod tests {
     extern crate anyhow;
 
     use super::*;
-    use crate::vocab::base_vocab::swap_key_values;
+    use crate::vocab::base_vocab::{swap_key_values, SpecialTokenMap};
     use crate::vocab::BertVocab;
     use std::collections::HashMap;
 
@@ -1600,6 +1600,17 @@ mod tests {
         .cloned()
         .collect();
 
+        let special_token_map = SpecialTokenMap {
+            unk_token: "[UNK]".to_string(),
+            pad_token: Some("[PAD]".to_string()),
+            bos_token: None,
+            sep_token: Some("[SEP]".to_string()),
+            cls_token: Some("[CLS]".to_string()),
+            eos_token: None,
+            mask_token: Some("[MASK]".to_string()),
+            additional_special_tokens: None,
+        };
+
         let special_values: HashMap<String, i64> = [
             ("[UNK]".to_owned(), 2),
             ("[CLS]".to_owned(), 4),
@@ -1617,7 +1628,7 @@ mod tests {
         BertVocab {
             values,
             indices,
-            unknown_value: "[UNK]",
+            special_token_map,
             special_values,
             special_indices,
         }

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -61,6 +61,44 @@ impl BertTokenizer {
         })
     }
 
+    /// Create a new instance of a `BertTokenizer`
+    /// Expects a vocabulary flat-file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the vocabulary file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
+    /// let strip_accents = false;
+    /// let lower_case = false;
+    /// let tokenizer = BertTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<BertTokenizer, TokenizerError> {
+        let vocab =
+            BertVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        let base_tokenizer =
+            BaseTokenizer::from_existing_vocab(vocab.clone(), lower_case, strip_accents);
+        Ok(BertTokenizer {
+            vocab,
+            base_tokenizer,
+        })
+    }
     /// Create a new instance of a `BertTokenizer` from an existing vocabulary
     ///
     /// # Parameters

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -126,25 +126,9 @@ impl Tokenizer<BertVocab> for BertTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .cls_token
-                    .as_ref()
-                    .expect("CLS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -160,15 +144,7 @@ impl Tokenizer<BertVocab> for BertTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -74,6 +74,50 @@ impl CtrlTokenizer {
         })
     }
 
+    /// Create a new instance of a `CtrlTokenizer`
+    /// Expects a vocabulary json file and a merges file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the vocabulary file
+    /// - merges_path (`&str`): path to the merges file (use as part of the BPE encoding process)
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = CtrlTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        vocab_path: &str,
+        merges_path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<CtrlTokenizer, TokenizerError> {
+        let vocab = OpenAiGptVocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let bpe_ranks = BpePairVocab::from_file(merges_path)?;
+        let cache = RwLock::new(HashMap::new());
+        let regex_pattern = Regex::new(r"\S+\n?").unwrap();
+        Ok(CtrlTokenizer {
+            vocab,
+            bpe_ranks,
+            cache,
+            regex_pattern,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `CtrlTokenizer` from an existing vocabulary and merges
     ///
     /// # Parameters

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -154,7 +154,7 @@ impl MultiThreadedTokenizer<OpenAiGptVocab> for CtrlTokenizer {}
 mod tests {
     use super::*;
     use crate::tokenizer::base_tokenizer::{Offset, TokenizedInput, TruncationStrategy};
-    use crate::vocab::base_vocab::swap_key_values;
+    use crate::vocab::base_vocab::{swap_key_values, SpecialTokenMap};
     use crate::vocab::OpenAiGptVocab;
     use crate::Mask;
     use itertools::Itertools;
@@ -175,6 +175,16 @@ mod tests {
         .cloned()
         .collect();
 
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: None,
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: None,
+            mask_token: None,
+            additional_special_tokens: None,
+        };
         let special_values: HashMap<String, i64> =
             [("<unk>".to_owned(), 6)].iter().cloned().collect();
 
@@ -184,7 +194,7 @@ mod tests {
         OpenAiGptVocab {
             values,
             indices,
-            unknown_value: "<unk>",
+            special_token_map,
             special_values,
             special_indices,
         }

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -189,25 +189,9 @@ impl Tokenizer<DeBERTaVocab> for DeBERTaTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .cls_token
-                    .as_ref()
-                    .expect("CLS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -223,15 +207,7 @@ impl Tokenizer<DeBERTaVocab> for DeBERTaTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -189,9 +189,25 @@ impl Tokenizer<DeBERTaVocab> for DeBERTaTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(self.vocab.token_to_id(DeBERTaVocab::cls_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .cls_token
+                    .as_ref()
+                    .expect("CLS token expected for encoding"),
+            ),
+        );
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(DeBERTaVocab::sep_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .sep_token
+                    .as_ref()
+                    .expect("SEP token expected for encoding"),
+            ),
+        );
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -207,7 +223,15 @@ impl Tokenizer<DeBERTaVocab> for DeBERTaTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(DeBERTaVocab::sep_value()));
+            output.push(
+                self.vocab.token_to_id(
+                    self.vocab
+                        .special_token_map
+                        .sep_token
+                        .as_ref()
+                        .expect("SEP token expected for encoding"),
+                ),
+            );
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -84,6 +84,53 @@ impl DeBERTaTokenizer {
         })
     }
 
+    /// Create a new instance of a `DeBERTaTokenizer`
+    /// Expects a vocabulary json file and a merges file as an input.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the vocabulary file
+    /// - merges_path (`&str`): path to the merges file (use as part of the BPE encoding process)
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = DeBERTaTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        vocab_path: &str,
+        merges_path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<DeBERTaTokenizer, TokenizerError> {
+        let vocab = DeBERTaVocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let bpe_ranks = BpePairVocab::from_file(merges_path)?;
+        let cache = RwLock::new(HashMap::new());
+        let pattern_lookahead = Regex::new(r"\s+\S").unwrap();
+        let pattern_tokenization =
+            Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+")
+                .unwrap();
+        Ok(DeBERTaTokenizer {
+            vocab,
+            bpe_ranks,
+            cache,
+            pattern_lookahead,
+            pattern_tokenization,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `DeBERTaTokenizer` from an existing vocabulary and merges
     ///
     /// # Parameters

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -17,7 +17,7 @@ use crate::tokenizer::tokenization_utils::{
 };
 use crate::tokenizer::tokenization_utils::{lowercase, unknown_byte_fallback};
 use crate::tokenizer::{MultiThreadedTokenizer, Tokenizer};
-use crate::vocab::{DeBERTaV2SpecialTokensMap, DeBERTaV2Vocab, SentencePieceModel, Vocab};
+use crate::vocab::{DeBERTaV2Vocab, SentencePieceModel, Vocab};
 use crate::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
 };
@@ -65,7 +65,7 @@ impl DeBERTaV2Tokenizer {
     /// ```
     pub fn from_file(
         path: &str,
-        secial_tokens_map_path: Option<&str>,
+        special_tokens_map_path: Option<&str>,
         lower_case: bool,
         strip_accents: bool,
         add_prefix_space: bool,
@@ -252,13 +252,25 @@ impl Tokenizer<DeBERTaV2Vocab> for DeBERTaV2Tokenizer {
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
         output.push(
-            self.vocab
-                .token_to_id(&self.vocab.special_tokens_map.cls_token),
+            self.vocab.token_to_id(
+                &self
+                    .vocab
+                    .special_token_map
+                    .cls_token
+                    .as_ref()
+                    .expect("DeBERTa requires a CLS token for encoding"),
+            ),
         );
         output.extend(tokens_ids_with_offsets_1.ids);
         output.push(
-            self.vocab
-                .token_to_id(&self.vocab.special_tokens_map.sep_token),
+            self.vocab.token_to_id(
+                &self
+                    .vocab
+                    .special_token_map
+                    .cls_token
+                    .as_ref()
+                    .expect("DeBERTa requires a SEP token for encoding"),
+            ),
         );
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -243,9 +243,15 @@ impl Tokenizer<DeBERTaV2Vocab> for DeBERTaV2Tokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(self.vocab.token_to_id(DeBERTaV2Vocab::cls_value()));
+        output.push(
+            self.vocab
+                .token_to_id(&self.vocab.special_tokens_map.cls_token),
+        );
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(DeBERTaV2Vocab::sep_value()));
+        output.push(
+            self.vocab
+                .token_to_id(&self.vocab.special_tokens_map.sep_token),
+        );
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -261,7 +267,10 @@ impl Tokenizer<DeBERTaV2Vocab> for DeBERTaV2Tokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(DeBERTaV2Vocab::sep_value()));
+            output.push(
+                self.vocab
+                    .token_to_id(&self.vocab.special_tokens_map.sep_token),
+            );
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -243,25 +243,9 @@ impl Tokenizer<DeBERTaV2Vocab> for DeBERTaV2Tokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .cls_token
-                    .as_ref()
-                    .expect("CLS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -277,15 +261,7 @@ impl Tokenizer<DeBERTaV2Vocab> for DeBERTaV2Tokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -17,7 +17,7 @@ use crate::tokenizer::tokenization_utils::{
 };
 use crate::tokenizer::tokenization_utils::{lowercase, unknown_byte_fallback};
 use crate::tokenizer::{MultiThreadedTokenizer, Tokenizer};
-use crate::vocab::{DeBERTaV2Vocab, SentencePieceModel, Vocab};
+use crate::vocab::{DeBERTaV2SpecialTokensMap, DeBERTaV2Vocab, SentencePieceModel, Vocab};
 use crate::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
 };
@@ -65,12 +65,20 @@ impl DeBERTaV2Tokenizer {
     /// ```
     pub fn from_file(
         path: &str,
+        secial_tokens_map_path: Option<&str>,
         lower_case: bool,
         strip_accents: bool,
         add_prefix_space: bool,
     ) -> Result<DeBERTaV2Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
-        let vocab = DeBERTaV2Vocab::from_file(path)?;
+        let vocab = DeBERTaV2Vocab::from_file_with_secial_tokens_map(
+            path,
+            secial_tokens_map_path
+                .map(DeBERTaV2SpecialTokensMap::from_file)
+                .transpose()?
+                .unwrap_or_default(),
+        )?;
+
         Ok(DeBERTaV2Tokenizer {
             model,
             vocab,

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -80,6 +80,50 @@ impl DeBERTaV2Tokenizer {
         })
     }
 
+    /// Create a new instance of a `DeBERTaV2Tokenizer`
+    /// Expects a SentencePiece BPE protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - add_prefix_space (`bool`): flag indicating if a space should be preprended to the input text before tokenization
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{DeBERTaV2Tokenizer, Tokenizer};
+    /// let strip_accents = false;
+    /// let lower_case = false;
+    /// let add_prefix_space = false;
+    /// let tokenizer = DeBERTaV2Tokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     add_prefix_space,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        add_prefix_space: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<DeBERTaV2Tokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab =
+            DeBERTaV2Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        Ok(DeBERTaV2Tokenizer {
+            model,
+            vocab,
+            lower_case,
+            strip_accents,
+            add_prefix_space,
+        })
+    }
+
     /// Create a new instance of a `DeBERTaV2Tokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -190,7 +190,7 @@ impl DeBERTaV2Tokenizer {
                     } else {
                         let first_char_length =
                             updated_tokens[0].text.chars().next().unwrap().len_utf8();
-                        updated_tokens[0].text = (&updated_tokens[0].text[first_char_length..])
+                        updated_tokens[0].text = (updated_tokens[0].text[first_char_length..])
                             .parse()
                             .unwrap();
                     }

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -212,9 +212,9 @@ impl Tokenizer<FNetVocab> for FNetTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(self.vocab.token_to_id(FNetVocab::cls_value()));
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(FNetVocab::sep_value()));
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -230,7 +230,7 @@ impl Tokenizer<FNetVocab> for FNetTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(FNetVocab::sep_value()));
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -71,6 +71,46 @@ impl FNetTokenizer {
         })
     }
 
+    /// Create a new instance of a `FNetTokenizer`
+    /// Expects a SentencePiece BPE protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{FNetTokenizer, Tokenizer};
+    /// let strip_accents = false;
+    /// let lower_case = false;
+    /// let tokenizer = FNetTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<FNetTokenizer, TokenizerError> {
+        let model = SentencePieceBpeModel::from_file(path)?;
+        let vocab =
+            FNetVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        Ok(FNetTokenizer {
+            model,
+            vocab,
+            lower_case,
+            strip_accents,
+        })
+    }
+
     /// Create a new instance of a `FNetTokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -166,7 +166,7 @@ impl FNetTokenizer {
                     } else {
                         let first_char_length =
                             updated_tokens[0].text.chars().next().unwrap().len_utf8();
-                        updated_tokens[0].text = (&updated_tokens[0].text[first_char_length..])
+                        updated_tokens[0].text = (updated_tokens[0].text[first_char_length..])
                             .parse()
                             .unwrap();
                     }

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -82,6 +82,54 @@ impl Gpt2Tokenizer {
         })
     }
 
+    /// Create a new instance of a `Gpt2Tokenizer`
+    /// Expects a vocabulary json file and a merges file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the vocabulary file
+    /// - merges_path (`&str`): path to the merges file (use as part of the BPE encoding process)
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = Gpt2Tokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        vocab_path: &str,
+        merges_path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<Gpt2Tokenizer, TokenizerError> {
+        let vocab = Gpt2Vocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let bpe_ranks = BpePairVocab::from_file(merges_path)?;
+        let cache = RwLock::new(HashMap::new());
+        let pattern_lookahead = Regex::new(r"\s+\S").unwrap();
+        let pattern_tokenization =
+            Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+")
+                .unwrap();
+        Ok(Gpt2Tokenizer {
+            vocab,
+            bpe_ranks,
+            cache,
+            pattern_lookahead,
+            pattern_tokenization,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `Gpt2Tokenizer` from an existing vocabulary and merges
     ///
     /// # Parameters

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -179,7 +179,7 @@ impl MultiThreadedTokenizer<Gpt2Vocab> for Gpt2Tokenizer {}
 mod tests {
     use super::*;
     use crate::tokenizer::base_tokenizer::TruncationStrategy;
-    use crate::vocab::base_vocab::swap_key_values;
+    use crate::vocab::base_vocab::{swap_key_values, SpecialTokenMap};
     use crate::vocab::Gpt2Vocab;
     use crate::{Offset, TokenizedInput};
     use std::collections::HashMap;
@@ -201,6 +201,17 @@ mod tests {
         .cloned()
         .collect();
 
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<|endoftext|>".to_string(),
+            pad_token: None,
+            bos_token: Some("<|endoftext|>".to_string()),
+            sep_token: None,
+            cls_token: None,
+            eos_token: Some("<|endoftext|>".to_string()),
+            mask_token: None,
+            additional_special_tokens: None,
+        };
+
         let special_values: HashMap<String, i64> =
             [("<|endoftext|>".to_owned(), 6)].iter().cloned().collect();
 
@@ -210,7 +221,7 @@ mod tests {
         Gpt2Vocab {
             values,
             indices,
-            unknown_value: "<|endoftext|>",
+            special_token_map,
             special_values,
             special_indices,
         }

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -70,6 +70,47 @@ impl M2M100Tokenizer {
         })
     }
 
+    /// Create a new instance of a `M2M100Tokenizer`
+    /// Expects a json vocab file and a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the JSON vocab file
+    /// - model_path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = M2M100Tokenizer::from_files_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/spiece/model/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_files_with_special_token_mapping(
+        vocab_path: &str,
+        model_path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<M2M100Tokenizer, TokenizerError> {
+        let vocab = M2M100Vocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let model = SentencePieceBpeModel::from_file(model_path)?;
+
+        Ok(M2M100Tokenizer {
+            model,
+            vocab,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `M2M100Tokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -191,7 +191,15 @@ impl Tokenizer<M2M100Vocab> for M2M100Tokenizer {
             token_segment_ids.push(0);
         }
         special_tokens_mask.push(1);
-        output.push(self.vocab.token_to_id(M2M100Vocab::eos_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .eos_token
+                    .as_ref()
+                    .expect("EOS token expected for encoding"),
+            ),
+        );
         offsets.push(None);
         original_offsets.push(vec![]);
         mask.push(Mask::Special);

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -191,15 +191,7 @@ impl Tokenizer<M2M100Vocab> for M2M100Tokenizer {
             token_segment_ids.push(0);
         }
         special_tokens_mask.push(1);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .eos_token
-                    .as_ref()
-                    .expect("EOS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_eos_value()));
         offsets.push(None);
         original_offsets.push(vec![]);
         mask.push(Mask::Special);

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -70,6 +70,48 @@ impl MarianTokenizer {
         })
     }
 
+    /// Create a new instance of a `MarianTokenizer`
+    /// Expects a json vocab file and a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the JSON vocab file
+    /// - model_path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = MarianTokenizer::from_files_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/model/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_files_with_special_token_mapping(
+        vocab_path: &str,
+        model_path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<MarianTokenizer, TokenizerError> {
+        let vocab = MarianVocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let model = SentencePieceModel::from_file(model_path)?;
+        let pattern_language_code = Regex::new(r">>.+<<").unwrap();
+        Ok(MarianTokenizer {
+            model,
+            vocab,
+            pattern_language_code,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `MarianTokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -214,15 +214,7 @@ impl Tokenizer<MarianVocab> for MarianTokenizer {
         }
         special_tokens_mask.push(1);
         token_segment_ids.push(1);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .eos_token
-                    .as_ref()
-                    .expect("EOS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_eos_value()));
         offsets.push(None);
         original_offsets.push(vec![]);
         mask.push(Mask::Special);

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -214,7 +214,15 @@ impl Tokenizer<MarianVocab> for MarianTokenizer {
         }
         special_tokens_mask.push(1);
         token_segment_ids.push(1);
-        output.push(self.vocab.token_to_id(MarianVocab::eos_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .eos_token
+                    .as_ref()
+                    .expect("EOS token expected for encoding"),
+            ),
+        );
         offsets.push(None);
         original_offsets.push(vec![]);
         mask.push(Mask::Special);

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -156,15 +156,7 @@ impl Tokenizer<MBart50Vocab> for MBart50Tokenizer {
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 1]);
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         if !offsets.is_empty() {
             offsets[0] = None;
@@ -186,15 +178,7 @@ impl Tokenizer<MBart50Vocab> for MBart50Tokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             offsets.push(None);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -59,6 +59,41 @@ impl MBart50Tokenizer {
         })
     }
 
+    /// Create a new instance of a `MBart50Tokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = MBart50Tokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<MBart50Tokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab =
+            MBart50Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        Ok(MBart50Tokenizer {
+            model,
+            vocab,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `MBart50Tokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -156,7 +156,15 @@ impl Tokenizer<MBart50Vocab> for MBart50Tokenizer {
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 1]);
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(MBart50Vocab::sep_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .sep_token
+                    .as_ref()
+                    .expect("SEP token expected for encoding"),
+            ),
+        );
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         if !offsets.is_empty() {
             offsets[0] = None;
@@ -178,7 +186,15 @@ impl Tokenizer<MBart50Vocab> for MBart50Tokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(MBart50Vocab::sep_value()));
+            output.push(
+                self.vocab.token_to_id(
+                    self.vocab
+                        .special_token_map
+                        .sep_token
+                        .as_ref()
+                        .expect("SEP token expected for encoding"),
+                ),
+            );
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             offsets.push(None);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -67,6 +67,49 @@ impl OpenAiGptTokenizer {
         })
     }
 
+    /// Create a new instance of a `OpenAiGptTokenizer`
+    /// Expects a vocabulary flat file and merges file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the vocabulary file
+    /// - merges_path (`&str`): path to the merges file (use as part of the BPE encoding process)
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = OpenAiGptTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        vocab_path: &str,
+        merges_path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<OpenAiGptTokenizer, TokenizerError> {
+        let vocab = OpenAiGptVocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let base_tokenizer = BaseTokenizer::from_existing_vocab(vocab.clone(), lower_case, true);
+        let bpe_ranks = BpePairVocab::from_file(merges_path)?;
+        let cache = RwLock::new(HashMap::new());
+        Ok(OpenAiGptTokenizer {
+            vocab,
+            base_tokenizer,
+            bpe_ranks,
+            cache,
+        })
+    }
+
     /// Create a new instance of a `OpenAiGptTokenizer` from an existing vocabulary and merges
     ///
     /// # Parameters

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -140,7 +140,7 @@ impl MultiThreadedTokenizer<OpenAiGptVocab> for OpenAiGptTokenizer {}
 mod tests {
     use super::*;
     use crate::tokenizer::base_tokenizer::{Offset, TokenizedInput, TruncationStrategy};
-    use crate::vocab::base_vocab::swap_key_values;
+    use crate::vocab::base_vocab::{swap_key_values, SpecialTokenMap};
     use crate::vocab::OpenAiGptVocab;
     use itertools::Itertools;
     use std::collections::HashMap;
@@ -163,6 +163,17 @@ mod tests {
         .cloned()
         .collect();
 
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: None,
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: None,
+            mask_token: None,
+            additional_special_tokens: None,
+        };
+
         let special_values: HashMap<String, i64> =
             [("<unk>".to_owned(), 6)].iter().cloned().collect();
 
@@ -172,7 +183,7 @@ mod tests {
         OpenAiGptVocab {
             values,
             indices,
-            unknown_value: "<unk>",
+            special_token_map,
             special_values,
             special_indices,
         }

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -179,15 +179,7 @@ impl Tokenizer<PegasusVocab> for PegasusTokenizer {
         }
         special_tokens_mask.push(1);
         token_segment_ids.push(1);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .eos_token
-                    .as_ref()
-                    .expect("EOS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_eos_value()));
         offsets.push(None);
         original_offsets.push(vec![]);
         mask.push(Mask::Special);

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -42,14 +42,47 @@ impl PegasusTokenizer {
     /// # Example
     ///
     /// ```no_run
-    /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
+    /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
     /// let lower_case = false;
-    /// let tokenizer =
-    ///     MarianTokenizer::from_files("path/to/vocab/file", "path/to/model/file", lower_case)
-    ///         .unwrap();
+    /// let tokenizer = PegasusTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file(path: &str, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab = PegasusVocab::from_file(path)?;
+        let model = SentencePieceModel::from_file(path)?;
+        Ok(PegasusTokenizer {
+            model,
+            vocab,
+            lower_case,
+        })
+    }
+
+    /// Create a new instance of a `PegasusTokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = PegasusTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<PegasusTokenizer, TokenizerError> {
+        let vocab =
+            PegasusVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         let model = SentencePieceModel::from_file(path)?;
         Ok(PegasusTokenizer {
             model,

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -179,7 +179,15 @@ impl Tokenizer<PegasusVocab> for PegasusTokenizer {
         }
         special_tokens_mask.push(1);
         token_segment_ids.push(1);
-        output.push(self.vocab.token_to_id(PegasusVocab::eos_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .eos_token
+                    .as_ref()
+                    .expect("EOS token expected for encoding"),
+            ),
+        );
         offsets.push(None);
         original_offsets.push(vec![]);
         mask.push(Mask::Special);

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -125,15 +125,7 @@ impl Tokenizer<ProphetNetVocab> for ProphetNetTokenizer {
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 1]);
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
         original_offsets.extend(tokens_ids_with_offsets_1.reference_offsets);
@@ -146,15 +138,7 @@ impl Tokenizer<ProphetNetVocab> for ProphetNetTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -60,6 +60,47 @@ impl ProphetNetTokenizer {
         })
     }
 
+    /// Create a new instance of a `ProphetNetTokenizer`.
+    /// Expects a vocabulary flat-file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the vocabulary file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{ProphetNetTokenizer, Tokenizer};
+    /// let strip_accents = false;
+    /// let lower_case = false;
+    /// let tokenizer = ProphetNetTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<ProphetNetTokenizer, TokenizerError> {
+        let vocab = ProphetNetVocab::from_file_with_special_token_mapping(
+            path,
+            special_token_mapping_path,
+        )?;
+        let base_tokenizer =
+            BaseTokenizer::from_existing_vocab(vocab.clone(), lower_case, strip_accents);
+        Ok(ProphetNetTokenizer {
+            vocab,
+            base_tokenizer,
+        })
+    }
+
     /// Create a new instance of a `ProphetNetTokenizer` from an existing vocabulary
     ///
     /// # Parameters

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -58,6 +58,44 @@ impl ReformerTokenizer {
             lower_case,
         })
     }
+
+    /// Create a new instance of a `ReformerTokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<ReformerTokenizer, TokenizerError> {
+        let vocab =
+            ReformerVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        let bpe_ranks = BpePairVocab::from_sentencepiece_file(path)?;
+        let cache = RwLock::new(HashMap::new());
+        Ok(ReformerTokenizer {
+            vocab,
+            bpe_ranks,
+            cache,
+            lower_case,
+        })
+    }
 }
 
 impl Tokenizer<ReformerVocab> for ReformerTokenizer {

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -217,9 +217,9 @@ impl Tokenizer<RobertaVocab> for RobertaTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(self.vocab.token_to_id(RobertaVocab::cls_value()));
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(RobertaVocab::sep_value()));
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -236,9 +236,9 @@ impl Tokenizer<RobertaVocab> for RobertaTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.push(0);
             token_segment_ids.extend(vec![1; length + 1]);
-            output.push(self.vocab.token_to_id(RobertaVocab::sep_value()));
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(RobertaVocab::sep_value()));
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.push(None);
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -95,6 +95,58 @@ impl RobertaTokenizer {
         })
     }
 
+    /// Create a new instance of a `RobertaTokenizer`
+    /// Expects a vocabulary json file and a merges file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - vocab_path (`&str`): path to the vocabulary file
+    /// - merges_path (`&str`): path to the merges file (use as part of the BPE encoding process)
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let add_prefix_space = true;
+    /// let tokenizer = RobertaTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
+    ///     lower_case,
+    ///     add_prefix_space,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        vocab_path: &str,
+        merges_path: &str,
+        lower_case: bool,
+        add_prefix_space: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<RobertaTokenizer, TokenizerError> {
+        let vocab = RobertaVocab::from_file_with_special_token_mapping(
+            vocab_path,
+            special_token_mapping_path,
+        )?;
+        let bpe_ranks = BpePairVocab::from_file(merges_path)?;
+        let cache = RwLock::new(HashMap::new());
+        let pattern_lookahead = Regex::new(r"\s+\S").unwrap();
+        let pattern_tokenization =
+            Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+")
+                .unwrap();
+        Ok(RobertaTokenizer {
+            vocab,
+            bpe_ranks,
+            cache,
+            pattern_lookahead,
+            pattern_tokenization,
+            lower_case,
+            add_prefix_space,
+        })
+    }
+
     /// Create a new instance of a `RobertaTokenizer` from an existing vocabulary and merges
     ///
     /// # Parameters

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -264,7 +264,7 @@ impl MultiThreadedTokenizer<RobertaVocab> for RobertaTokenizer {}
 mod tests {
     use super::*;
     use crate::tokenizer::base_tokenizer::{TokenizedInput, TruncationStrategy};
-    use crate::vocab::base_vocab::swap_key_values;
+    use crate::vocab::base_vocab::{swap_key_values, SpecialTokenMap};
     use crate::vocab::RobertaVocab;
     use std::collections::HashMap;
 
@@ -289,6 +289,17 @@ mod tests {
         .cloned()
         .collect();
 
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: Some("<pad>".to_string()),
+            bos_token: Some("<s>".to_string()),
+            sep_token: Some("</s>".to_string()),
+            cls_token: Some("<s>".to_string()),
+            eos_token: Some("</s>".to_string()),
+            mask_token: Some("<mask>".to_string()),
+            additional_special_tokens: None,
+        };
+
         let special_values: HashMap<String, i64> = [
             ("<unk>".to_owned(), 6),
             ("<s>".to_owned(), 8),
@@ -306,7 +317,7 @@ mod tests {
         RobertaVocab {
             values,
             indices,
-            unknown_value: "<unk>",
+            special_token_map,
             special_values,
             special_indices,
         }

--- a/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
@@ -31,6 +31,44 @@ pub struct SentencePieceBpeTokenizer {
 
 impl SentencePieceBpeTokenizer {
     /// Create a new instance of a `SentencePieceBpeTokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<SentencePieceBpeTokenizer, TokenizerError> {
+        let model = SentencePieceBpeModel::from_file(path)?;
+        let vocab = SentencePieceVocab::from_file_with_special_token_mapping(
+            path,
+            special_token_mapping_path,
+        )?;
+        Ok(SentencePieceBpeTokenizer {
+            model,
+            vocab,
+            lower_case,
+        })
+    }
+
+    /// Create a new instance of a `SentencePieceBpeTokenizer`
     /// Expects a SentencePiece protobuf file as an input.
     ///
     /// # Parameters

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -58,6 +58,43 @@ impl SentencePieceTokenizer {
         })
     }
 
+    /// Create a new instance of a `SentencePieceTokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<SentencePieceTokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab = SentencePieceVocab::from_file_with_special_token_mapping(
+            path,
+            special_token_mapping_path,
+        )?;
+        Ok(SentencePieceTokenizer {
+            model,
+            vocab,
+            lower_case,
+        })
+    }
     /// Create a new instance of a `SentencePieceTokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -59,6 +59,42 @@ impl T5Tokenizer {
         })
     }
 
+    /// Create a new instance of a `T5Tokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = T5Tokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<T5Tokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab =
+            T5Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
+        Ok(T5Tokenizer {
+            model,
+            vocab,
+            lower_case,
+            eos_token_id,
+        })
+    }
+
     /// Create a new instance of a `T5Tokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -50,7 +50,7 @@ impl T5Tokenizer {
     pub fn from_file(path: &str, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab = T5Vocab::from_file(path)?;
-        let eos_token_id = vocab.token_to_id(T5Vocab::eos_value());
+        let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
         Ok(T5Tokenizer {
             model,
             vocab,
@@ -82,7 +82,7 @@ impl T5Tokenizer {
         model: SentencePieceModel,
         lower_case: bool,
     ) -> T5Tokenizer {
-        let eos_token_id = vocab.token_to_id(T5Vocab::eos_value());
+        let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
         T5Tokenizer {
             model,
             vocab,

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -149,9 +149,9 @@ impl Tokenizer<XLMRobertaVocab> for XLMRobertaTokenizer {
         special_tokens_mask.extend(vec![0; tokens_ids_with_offsets_1.ids.len()]);
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 2]);
-        output.push(self.vocab.token_to_id(XLMRobertaVocab::cls_value()));
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(XLMRobertaVocab::sep_value()));
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.push(None);
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
@@ -167,9 +167,9 @@ impl Tokenizer<XLMRobertaVocab> for XLMRobertaTokenizer {
             special_tokens_mask.extend(vec![0; length]);
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 2]);
-            output.push(self.vocab.token_to_id(XLMRobertaVocab::sep_value()));
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(XLMRobertaVocab::sep_value()));
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.push(None);
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.push(vec![]);

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -59,6 +59,43 @@ impl XLMRobertaTokenizer {
         })
     }
 
+    /// Create a new instance of a `XLMRobertaTokenizer`
+    /// Expects a json vocab file and a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
+    /// let lower_case = false;
+    /// let tokenizer = XLMRobertaTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<XLMRobertaTokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab = XLMRobertaVocab::from_file_with_special_token_mapping(
+            path,
+            special_token_mapping_path,
+        )?;
+        Ok(XLMRobertaTokenizer {
+            model,
+            vocab,
+            lower_case,
+        })
+    }
+
     /// Create a new instance of a `MarianTokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -216,7 +216,15 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 1]);
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(self.vocab.token_to_id(XLNetVocab::sep_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .sep_token
+                    .as_ref()
+                    .expect("SEP token expected for encoding"),
+            ),
+        );
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
         original_offsets.extend(tokens_ids_with_offsets_1.reference_offsets);
@@ -230,7 +238,15 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(self.vocab.token_to_id(XLNetVocab::sep_value()));
+            output.push(
+                self.vocab.token_to_id(
+                    self.vocab
+                        .special_token_map
+                        .sep_token
+                        .as_ref()
+                        .expect("SEP token expected for encoding"),
+                ),
+            );
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);
@@ -239,7 +255,15 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
             mask.push(Mask::Special);
         }
         // Push the CLS token at the end of the sequence
-        output.push(self.vocab.token_to_id(XLNetVocab::cls_value()));
+        output.push(
+            self.vocab.token_to_id(
+                self.vocab
+                    .special_token_map
+                    .cls_token
+                    .as_ref()
+                    .expect("CLS token expected for encoding"),
+            ),
+        );
         special_tokens_mask.push(1);
         offsets.push(None);
         original_offsets.push(vec![]);

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -69,6 +69,46 @@ impl XLNetTokenizer {
         })
     }
 
+    /// Create a new instance of a `XLNetTokenizer`
+    /// Expects a SentencePiece protobuf file and special token mapping file as inputs.
+    ///
+    /// # Parameters
+    /// - path (`&str`): path to the SentencePiece model file
+    /// - lower_case (`bool`): flag indicating if the text should be lower-cased as part of the tokenization
+    /// - strip_accents (`bool`): flag indicating if accents should be stripped from the text
+    /// - special_token_mapping_path (`&str`): path to a special token mapping file to overwrite default special tokens
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
+    /// let lower_case = false;
+    /// let strip_accents = false;
+    /// let tokenizer = XLNetTokenizer::from_file_with_special_token_mapping(
+    ///     "path/to/vocab/file",
+    ///     lower_case,
+    ///     strip_accents,
+    ///     "path/to/special/token/mapping/file",
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn from_file_with_special_token_mapping(
+        path: &str,
+        lower_case: bool,
+        strip_accents: bool,
+        special_token_mapping_path: &str,
+    ) -> Result<XLNetTokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(path)?;
+        let vocab =
+            XLNetVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        Ok(XLNetTokenizer {
+            model,
+            vocab,
+            lower_case,
+            strip_accents,
+        })
+    }
+
     /// Create a new instance of a `XLNetTokenizer` from an existing vocabulary and model
     ///
     /// # Parameters

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -216,15 +216,7 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
         special_tokens_mask.push(1);
         token_segment_ids.extend(vec![0; tokens_ids_with_offsets_1.ids.len() + 1]);
         output.extend(tokens_ids_with_offsets_1.ids);
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .sep_token
-                    .as_ref()
-                    .expect("SEP token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
         offsets.extend(tokens_ids_with_offsets_1.offsets);
         offsets.push(None);
         original_offsets.extend(tokens_ids_with_offsets_1.reference_offsets);
@@ -238,15 +230,7 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
             special_tokens_mask.push(1);
             token_segment_ids.extend(vec![1; length + 1]);
             output.extend(tokens_ids_with_offsets_2_value.ids);
-            output.push(
-                self.vocab.token_to_id(
-                    self.vocab
-                        .special_token_map
-                        .sep_token
-                        .as_ref()
-                        .expect("SEP token expected for encoding"),
-                ),
-            );
+            output.push(self.vocab.token_to_id(self.vocab.get_sep_value()));
             offsets.extend(tokens_ids_with_offsets_2_value.offsets);
             original_offsets.extend(tokens_ids_with_offsets_2_value.reference_offsets);
             offsets.push(None);
@@ -255,15 +239,7 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
             mask.push(Mask::Special);
         }
         // Push the CLS token at the end of the sequence
-        output.push(
-            self.vocab.token_to_id(
-                self.vocab
-                    .special_token_map
-                    .cls_token
-                    .as_ref()
-                    .expect("CLS token expected for encoding"),
-            ),
-        );
+        output.push(self.vocab.token_to_id(self.vocab.get_cls_value()));
         special_tokens_mask.push(1);
         offsets.push(None);
         original_offsets.push(vec![]);

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -165,7 +165,7 @@ impl XLNetTokenizer {
                         } else {
                             let first_char_length =
                                 updated_tokens[0].text.chars().next().unwrap().len_utf8();
-                            updated_tokens[0].text = (&updated_tokens[0].text[first_char_length..])
+                            updated_tokens[0].text = (updated_tokens[0].text[first_char_length..])
                                 .parse()
                                 .unwrap();
                         }

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -71,7 +71,7 @@ impl Vocab for AlbertVocab {
     }
 
     fn from_file(path: &str) -> Result<AlbertVocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -49,6 +49,58 @@ pub struct AlbertVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_BOS_TOKEN: &str = "[CLS]";
+const DEFAULT_SEP_TOKEN: &str = "[SEP]";
+const DEFAULT_CLS_TOKEN: &str = "[CLS]";
+const DEFAULT_EOS_TOKEN: &str = "[SEP]";
+const DEFAULT_MASK_TOKEN: &str = "[MASK]";
+
+impl AlbertVocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+}
+
 impl Vocab for AlbertVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -74,13 +126,13 @@ impl Vocab for AlbertVocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
-            bos_token: Some("[CLS]".to_string()),
-            sep_token: Some("[SEP]".to_string()),
-            cls_token: Some("[CLS]".to_string()),
-            eos_token: Some("[SEP]".to_string()),
-            mask_token: Some("[MASK]".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
@@ -39,8 +41,8 @@ pub struct AlbertVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask
@@ -51,45 +53,9 @@ pub struct AlbertVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
-impl AlbertVocab {
-    /// Returns the BOS token for Albert (`[CLS]`)
-    pub fn bos_value() -> &'static str {
-        "[CLS]"
-    }
-
-    /// Returns the EOS token for Albert (`[SEP]`)
-    pub fn eos_value() -> &'static str {
-        "[SEP]"
-    }
-
-    /// Returns the SEP token for Albert (`[SEP]`)
-    pub fn sep_value() -> &'static str {
-        "[SEP]"
-    }
-
-    /// Returns the CLS token for Albert (`[CLS]`)
-    pub fn cls_value() -> &'static str {
-        "[CLS]"
-    }
-
-    /// Returns the MASK token for Albert (`[MASK]`)
-    pub fn mask_value() -> &'static str {
-        "[MASK]"
-    }
-
-    /// Returns the PAD token for Albert (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
-    }
-}
-
 impl Vocab for AlbertVocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -109,59 +75,28 @@ impl Vocab for AlbertVocab {
     }
 
     fn from_file(path: &str) -> Result<AlbertVocab, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
+        let mut values = read_protobuf_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: Some("<pad>".to_string()),
+            bos_token: Some("[CLS]".to_string()),
+            sep_token: Some("[SEP]".to_string()),
+            cls_token: Some("[CLS]".to_string()),
+            eos_token: Some("[SEP]".to_string()),
+            mask_token: Some("[MASK]".to_string()),
+            additional_special_tokens: None,
         };
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let mut values = HashMap::new();
-        for (idx, piece) in proto.get_pieces().iter().enumerate() {
-            values.insert(piece.get_piece().to_owned(), idx as i64);
-        }
-
-        let mut special_values = HashMap::new();
-        let unknown_value = AlbertVocab::unknown_value();
-        AlbertVocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
-
-        let bos_value = AlbertVocab::bos_value();
-        AlbertVocab::_register_as_special_value(bos_value, &values, &mut special_values)?;
-
-        let eos_value = AlbertVocab::eos_value();
-        AlbertVocab::_register_as_special_value(eos_value, &values, &mut special_values)?;
-
-        let cls_value = AlbertVocab::cls_value();
-        AlbertVocab::_register_as_special_value(cls_value, &values, &mut special_values)?;
-
-        let mask_value = AlbertVocab::mask_value();
-        AlbertVocab::_register_as_special_value(mask_value, &values, &mut special_values)?;
-
-        let pad_value = AlbertVocab::pad_value();
-        AlbertVocab::_register_as_special_value(pad_value, &values, &mut special_values)?;
-
-        let sep_value = AlbertVocab::sep_value();
-        AlbertVocab::_register_as_special_value(sep_value, &values, &mut special_values)?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(AlbertVocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_protobuf_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -16,12 +16,8 @@ use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
     read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 
 /// # AlbertVocab
 /// Vocabulary for ALBERT tokenizer. Contains the following special values:
@@ -99,16 +95,42 @@ impl Vocab for AlbertVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -152,7 +152,7 @@ impl Vocab for AlbertVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -103,10 +103,7 @@ pub(crate) fn read_special_token_mapping_file(
     })?;
     let br = BufReader::new(f);
     serde_json::from_reader(br).map_err(|e| {
-        TokenizerError::FileNotFound(format!(
-            "Invalid special token mapping file {}",
-            e.to_string()
-        ))
+        TokenizerError::FileNotFound(format!("Invalid special token mapping file {}", e))
     })
 }
 
@@ -154,28 +151,28 @@ impl SpecialTokenMap {
         values: &HashMap<String, i64>,
         special_values: &mut HashMap<String, i64>,
     ) -> Result<(), TokenizerError> {
-        register_as_special_value(self.unk_token.as_str(), &values, special_values)?;
+        register_as_special_value(self.unk_token.as_str(), values, special_values)?;
         if let Some(pad_token) = &self.pad_token {
-            register_as_special_value(pad_token, &values, special_values)?;
+            register_as_special_value(pad_token, values, special_values)?;
         }
         if let Some(bos_token) = &self.bos_token {
-            register_as_special_value(bos_token, &values, special_values)?;
+            register_as_special_value(bos_token, values, special_values)?;
         }
         if let Some(sep_token) = &self.sep_token {
-            register_as_special_value(sep_token, &values, special_values)?;
+            register_as_special_value(sep_token, values, special_values)?;
         }
         if let Some(cls_token) = &self.cls_token {
-            register_as_special_value(cls_token, &values, special_values)?;
+            register_as_special_value(cls_token, values, special_values)?;
         }
         if let Some(eos_token) = &self.eos_token {
-            register_as_special_value(eos_token, &values, special_values)?;
+            register_as_special_value(eos_token, values, special_values)?;
         }
         if let Some(mask_token) = &self.mask_token {
-            register_as_special_value(mask_token, &values, special_values)?;
+            register_as_special_value(mask_token, values, special_values)?;
         }
         if let Some(additional_special_tokens) = &self.additional_special_tokens {
             for token in additional_special_tokens {
-                register_as_special_value(token, &values, special_values)?;
+                register_as_special_value(token, values, special_values)?;
             }
         }
         Ok(())
@@ -421,7 +418,7 @@ impl Vocab for BaseVocab {
             token,
             &self.values,
             &self.special_values,
-            &self.get_unknown_value(),
+            self.get_unknown_value(),
         )
     }
 
@@ -430,7 +427,7 @@ impl Vocab for BaseVocab {
             id,
             &self.indices,
             &self.special_indices,
-            &self.get_unknown_value(),
+            self.get_unknown_value(),
         )
     }
 }

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -63,8 +63,7 @@ pub(crate) fn read_json_file(path: &str) -> Result<HashMap<String, i64>, Tokeniz
     Ok(values)
 }
 
-/// Read a SentencePiece protobuf file and extract vocabulary from it.
-pub(crate) fn read_protobuf_file(path: &str) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn open_protobuf_file(path: &str) -> Result<ModelProto, TokenizerError> {
     let mut f = File::open(path).map_err(|e| {
         TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
     })?;
@@ -80,6 +79,12 @@ pub(crate) fn read_protobuf_file(path: &str) -> Result<HashMap<String, i64>, Tok
             return Err(TokenizerError::VocabularyParsingError(e.to_string()));
         }
     };
+    Ok(proto)
+}
+
+/// Read a SentencePiece protobuf file and extract vocabulary from it.
+pub(crate) fn read_protobuf_file(path: &str) -> Result<HashMap<String, i64>, TokenizerError> {
+    let proto = open_protobuf_file(path)?;
 
     let mut values = HashMap::new();
     for (idx, piece) in proto.get_pieces().iter().enumerate() {

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -209,7 +209,7 @@ pub trait Vocab {
     /// ```
     fn from_file(path: &str) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized;
+        Self: Sized;
 
     /// Read a vocabulary from file with special token mapping
     ///
@@ -227,14 +227,14 @@ pub trait Vocab {
         special_token_mapping_path: &str,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized;
+        Self: Sized;
 
     fn from_values_and_special_token_map(
         values: HashMap<String, i64>,
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized;
+        Self: Sized;
 
     /// Converts a token to an id, provided a `HashMap` of values, a `HashMap` of special values and
     /// the unknown value token string representation. This is not meant to be directly used, the method
@@ -399,7 +399,7 @@ impl Vocab for BaseVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -347,6 +347,8 @@ pub struct BaseVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "[UNK]";
+
 impl Vocab for BaseVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -371,7 +373,7 @@ impl Vocab for BaseVocab {
     fn from_file(path: &str) -> Result<BaseVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {
-            unk_token: "[UNK]".to_string(),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
             pad_token: None,
             bos_token: None,
             sep_token: None,

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -102,8 +102,12 @@ pub(crate) fn read_special_token_mapping_file(
         TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
     })?;
     let br = BufReader::new(f);
-    serde_json::from_reader(br)
-        .map_err(|e| TokenizerError::FileNotFound("Invalid special token mapping file".into()))
+    serde_json::from_reader(br).map_err(|e| {
+        TokenizerError::FileNotFound(format!(
+            "Invalid special token mapping file {}",
+            e.to_string()
+        ))
+    })
 }
 
 /// Register a token as a special value
@@ -131,7 +135,7 @@ pub(crate) fn register_as_special_value(
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct SpecialTokenMap {
+pub struct SpecialTokenMap {
     pub unk_token: String,
     pub pad_token: Option<String>,
     pub bos_token: Option<String>,
@@ -470,7 +474,6 @@ mod tests {
 
         //        Then
         assert_eq!(base_vocab.get_unknown_value(), "[UNK]");
-        assert_eq!(base_vocab.get_unknown_value(), special_token_map.unk_token);
         assert_eq!(base_vocab.values, *base_vocab.values());
         assert_eq!(base_vocab.special_values, *base_vocab.special_values());
     }
@@ -498,7 +501,7 @@ mod tests {
         let base_vocab = BaseVocab::from_file(path.to_path_buf().to_str().unwrap())?;
 
         //        Then
-        assert_eq!(base_vocab.unknown_value, "[UNK]");
+        assert_eq!(base_vocab.get_unknown_value(), "[UNK]");
         assert_eq!(base_vocab.values, target_values);
         assert_eq!(base_vocab.special_values, special_values);
         drop(path);

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -45,6 +45,42 @@ pub struct BertVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "[UNK]";
+const DEFAULT_PAD_TOKEN: &str = "[PAD]";
+const DEFAULT_SEP_TOKEN: &str = "[SEP]";
+const DEFAULT_CLS_TOKEN: &str = "[CLS]";
+const DEFAULT_MASK_TOKEN: &str = "[MASK]";
+
+impl BertVocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+}
+
 impl Vocab for BertVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -69,13 +105,13 @@ impl Vocab for BertVocab {
     fn from_file(path: &str) -> Result<BertVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {
-            unk_token: "[UNK]".to_string(),
-            pad_token: Some("[PAD]".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
-            sep_token: Some("[SEP]".to_string()),
-            cls_token: Some("[CLS]".to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
             eos_token: None,
-            mask_token: Some("[MASK]".to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -12,7 +12,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::{swap_key_values, Vocab};
+use crate::vocab::base_vocab::{
+    read_flat_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
+};
 use std::collections::HashMap;
 
 /// # BERT Vocab
@@ -31,8 +33,8 @@ pub struct BertVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask
@@ -43,35 +45,9 @@ pub struct BertVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
-impl BertVocab {
-    /// Returns the PAD token for BERT (`[PAD]`)
-    pub fn pad_value() -> &'static str {
-        "[PAD]"
-    }
-
-    /// Returns the SEP token for BERT (`[SEP]`)
-    pub fn sep_value() -> &'static str {
-        "[SEP]"
-    }
-
-    /// Returns the CLS token for BERT (`[CLS]`)
-    pub fn cls_value() -> &'static str {
-        "[CLS]"
-    }
-
-    /// Returns the MASK token for BERT (`[MASK]`)
-    pub fn mask_value() -> &'static str {
-        "[MASK]"
-    }
-}
-
 impl Vocab for BertVocab {
-    fn unknown_value() -> &'static str {
-        "[UNK]"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "[UNK]"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -91,34 +67,27 @@ impl Vocab for BertVocab {
     }
 
     fn from_file(path: &str) -> Result<BertVocab, TokenizerError> {
-        let values = BertVocab::read_vocab_file(path)?;
-        let mut special_values = HashMap::new();
+        let values = read_flat_file(path)?;
+        let special_token_map = SpecialTokenMap {
+            unk_token: "[UNK]".to_string(),
+            pad_token: Some("[PAD]".to_string()),
+            bos_token: None,
+            sep_token: Some("[SEP]".to_string()),
+            cls_token: Some("[CLS]".to_string()),
+            eos_token: None,
+            mask_token: Some("[MASK]".to_string()),
+            additional_special_tokens: None,
+        };
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let unknown_value = BertVocab::unknown_value();
-        BertVocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
-
-        let pad_value = BertVocab::pad_value();
-        BertVocab::_register_as_special_value(pad_value, &values, &mut special_values)?;
-
-        let sep_value = BertVocab::sep_value();
-        BertVocab::_register_as_special_value(sep_value, &values, &mut special_values)?;
-
-        let cls_value = BertVocab::cls_value();
-        BertVocab::_register_as_special_value(cls_value, &values, &mut special_values)?;
-
-        let mask_value = BertVocab::mask_value();
-        BertVocab::_register_as_special_value(mask_value, &values, &mut special_values)?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(BertVocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_flat_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {
@@ -151,26 +120,30 @@ mod tests {
         let special_values: HashMap<String, i64> = HashMap::new();
         let indices: HashMap<i64, String> = HashMap::new();
         let special_indices: HashMap<i64, String> = HashMap::new();
-        let unknown_value = BertVocab::unknown_value();
+        let special_token_map = SpecialTokenMap {
+            unk_token: "[UNK]".to_string(),
+            pad_token: Some("[PAD]".to_string()),
+            bos_token: None,
+            sep_token: Some("[SEP]".to_string()),
+            cls_token: Some("[CLS]".to_string()),
+            eos_token: None,
+            mask_token: Some("[MASK]".to_string()),
+            additional_special_tokens: None,
+        };
 
         //        When
-        let base_vocab = BertVocab {
+        let bert_vocab = BertVocab {
             values,
             indices,
-            unknown_value,
+            special_token_map,
             special_values,
             special_indices,
         };
 
         //        Then
-        assert_eq!(base_vocab.unknown_value, "[UNK]");
-        assert_eq!(base_vocab.unknown_value, BertVocab::unknown_value());
-        assert_eq!(BertVocab::pad_value(), "[PAD]");
-        assert_eq!(BertVocab::sep_value(), "[SEP]");
-        assert_eq!(BertVocab::cls_value(), "[CLS]");
-        assert_eq!(BertVocab::mask_value(), "[MASK]");
-        assert_eq!(base_vocab.values, *base_vocab.values());
-        assert_eq!(base_vocab.special_values, *base_vocab.special_values());
+        assert_eq!(bert_vocab.get_unknown_value(), "[UNK]");
+        assert_eq!(bert_vocab.values, *bert_vocab.values());
+        assert_eq!(bert_vocab.special_values, *bert_vocab.special_values());
     }
 
     #[test]
@@ -208,12 +181,12 @@ mod tests {
         .collect();
 
         //        When
-        let base_vocab = BertVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let bert_vocab = BertVocab::from_file(path.to_path_buf().to_str().unwrap())?;
 
         //        Then
-        assert_eq!(base_vocab.unknown_value, "[UNK]");
-        assert_eq!(base_vocab.values, target_values);
-        assert_eq!(base_vocab.special_values, special_values);
+        assert_eq!(bert_vocab.get_unknown_value(), "[UNK]");
+        assert_eq!(bert_vocab.values, target_values);
+        assert_eq!(bert_vocab.special_values, special_values);
         drop(path);
         Ok(())
     }

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -131,7 +131,7 @@ impl Vocab for BertVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -90,17 +90,42 @@ impl Vocab for BertVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }
 

--- a/main/src/vocab/bpe_vocab.rs
+++ b/main/src/vocab/bpe_vocab.rs
@@ -37,7 +37,7 @@ pub struct BpePairVocab {
 }
 
 impl BpePairVocab {
-    /// Create a new `BpePairVocab` from a flat file containing merges in the format `first elment second element`)
+    /// Create a new `BpePairVocab` from a flat file containing merges in the format `first_element second_element`)
     /// The indices are implied by the lien position of each pair in the merges file. The first line needs to be a
     /// header and is skipped.
     ///

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -48,6 +48,58 @@ pub struct DeBERTaV2Vocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "[UNK]";
+const DEFAULT_PAD_TOKEN: &str = "[PAD]";
+const DEFAULT_BOS_TOKEN: &str = "[CLS]";
+const DEFAULT_SEP_TOKEN: &str = "[SEP]";
+const DEFAULT_CLS_TOKEN: &str = "[CLS]";
+const DEFAULT_EOS_TOKEN: &str = "[SEP]";
+const DEFAULT_MASK_TOKEN: &str = "[MASK]";
+
+impl DeBERTaV2Vocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+}
+
 impl Vocab for DeBERTaV2Vocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -73,23 +125,21 @@ impl Vocab for DeBERTaV2Vocab {
         let mut values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "[UNK]".to_string(),
-            pad_token: Some("[PAD]".to_string()),
-            bos_token: Some("[CLS]".to_string()),
-            sep_token: Some("[SEP]".to_string()),
-            cls_token: Some("[CLS]".to_string()),
-            eos_token: Some("[SEP]".to_string()),
-            mask_token: Some("[MASK]".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
-
         if !values.contains_key(special_token_map.mask_token.as_ref().unwrap()) {
             values.insert(
                 special_token_map.mask_token.as_ref().unwrap().clone(),
                 values.len() as i64,
             );
         }
-
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
@@ -103,9 +153,9 @@ impl Vocab for DeBERTaV2Vocab {
         if let Some(mask_token) = &special_token_map.mask_token {
             values.insert(mask_token.clone(), values.len() as i64);
         }
-
         Self::from_values_and_special_token_map(values, special_token_map)
     }
+
     fn from_values_and_special_token_map(
         values: HashMap<String, i64>,
         special_token_map: SpecialTokenMap,
@@ -126,6 +176,7 @@ impl Vocab for DeBERTaV2Vocab {
             special_indices,
         })
     }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -61,6 +61,20 @@ pub struct DeBERTaV2SpecialTokensMap {
     pub mask_token: String,
 }
 
+impl DeBERTaV2SpecialTokensMap {
+    pub fn from_file(path: &str) -> Result<Self, TokenizerError> {
+        let f = File::open(path).map_err(|e| {
+            TokenizerError::FileNotFound(format!(
+                "{} special token map file not found :{}",
+                path, e
+            ))
+        })?;
+
+        serde_json::from_reader(f)
+            .map_err(|e| TokenizerError::VocabularyParsingError(e.to_string()))
+    }
+}
+
 impl Default for DeBERTaV2SpecialTokensMap {
     fn default() -> Self {
         Self {

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -131,7 +131,7 @@ impl Vocab for DeBERTaV2Vocab {
             token,
             &self.values,
             &self.special_values,
-            &self.get_unknown_value(),
+            self.get_unknown_value(),
         )
     }
 
@@ -140,7 +140,7 @@ impl Vocab for DeBERTaV2Vocab {
             id,
             &self.indices,
             &self.special_indices,
-            &self.get_unknown_value(),
+            self.get_unknown_value(),
         )
     }
 }

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -11,7 +11,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
@@ -38,6 +40,9 @@ pub struct DeBERTaV2Vocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
+
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask
     /// markers and padding markers
@@ -45,34 +50,6 @@ pub struct DeBERTaV2Vocab {
 
     /// A mapping of special value tokens as IDs to strings (i.e. the decoder base for special values)
     pub special_indices: HashMap<i64, String>,
-
-    /// A mapping of special value tokens
-    pub special_tokens_map: DeBERTaV2SpecialTokensMap,
-}
-
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct DeBERTaV2SpecialTokensMap {
-    pub bos_token: String,
-    pub eos_token: String,
-    pub unk_token: String,
-    pub sep_token: String,
-    pub pad_token: String,
-    pub cls_token: String,
-    pub mask_token: String,
-}
-
-impl DeBERTaV2SpecialTokensMap {
-    pub fn from_file(path: &str) -> Result<Self, TokenizerError> {
-        let f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!(
-                "{} special token map file not found :{}",
-                path, e
-            ))
-        })?;
-
-        serde_json::from_reader(f)
-            .map_err(|e| TokenizerError::VocabularyParsingError(e.to_string()))
-    }
 }
 
 impl Default for DeBERTaV2SpecialTokensMap {
@@ -89,94 +66,9 @@ impl Default for DeBERTaV2SpecialTokensMap {
     }
 }
 
-impl DeBERTaV2Vocab {
-    pub fn from_file_with_secial_tokens_map(
-        path: &str,
-        special_tokens_map: DeBERTaV2SpecialTokensMap,
-    ) -> Result<DeBERTaV2Vocab, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
-        };
-
-        let mut values = HashMap::new();
-        for (idx, piece) in proto.get_pieces().iter().enumerate() {
-            values.insert(piece.get_piece().to_owned(), idx as i64);
-        }
-        if !values.contains_key(&special_tokens_map.mask_token) {
-            values.insert(special_tokens_map.mask_token.clone(), values.len() as i64);
-        }
-
-        let mut special_values = HashMap::new();
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.unk_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.bos_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.eos_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.cls_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.mask_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.pad_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        DeBERTaV2Vocab::_register_as_special_value(
-            &special_tokens_map.sep_token,
-            &values,
-            &mut special_values,
-        )?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(DeBERTaV2Vocab {
-            values,
-            indices,
-            special_values,
-            special_indices,
-            special_tokens_map,
-        })
-    }
-}
-
 impl Vocab for DeBERTaV2Vocab {
-    fn get_unknown_value(&self) -> &'static str {
-        "[UNK]"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -196,7 +88,41 @@ impl Vocab for DeBERTaV2Vocab {
     }
 
     fn from_file(path: &str) -> Result<DeBERTaV2Vocab, TokenizerError> {
-        Self::from_file_with_secial_tokens_map(path, Default::default())
+        let mut values = read_protobuf_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "[UNK]".to_string(),
+            pad_token: Some("[PAD]".to_string()),
+            bos_token: Some("[CLS]".to_string()),
+            sep_token: Some("[SEP]".to_string()),
+            cls_token: Some("[CLS]".to_string()),
+            eos_token: Some("[SEP]".to_string()),
+            mask_token: Some("[MASK]".to_string()),
+            additional_special_tokens: None,
+        };
+
+        if !values.contains_key(special_token_map.mask_token.as_ref().unwrap()) {
+            values.insert(
+                special_token_map.mask_token.as_ref().unwrap().clone(),
+                values.len() as i64,
+            );
+        }
+
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
+
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let mut values = read_protobuf_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+
+        if let Some(mask_token) = &special_token_map.mask_token {
+            values.insert(mask_token.clone(), values.len() as i64);
+        }
+
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -161,7 +161,7 @@ impl Vocab for DeBERTaV2Vocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -175,10 +175,6 @@ impl DeBERTaV2Vocab {
 }
 
 impl Vocab for DeBERTaV2Vocab {
-    fn unknown_value() -> &'static str {
-        "[UNK]"
-    }
-
     fn get_unknown_value(&self) -> &'static str {
         "[UNK]"
     }

--- a/main/src/vocab/deberta_vocab.rs
+++ b/main/src/vocab/deberta_vocab.rs
@@ -16,8 +16,6 @@ use crate::vocab::base_vocab::{
     read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
 
 /// # DeBERTa Vocab
 /// Vocabulary for DeBERTa tokenizer. Contains the following special values:
@@ -95,17 +93,41 @@ impl Vocab for DeBERTaVocab {
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
         Self::from_values_and_special_token_map(values, special_token_map)
     }
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
 
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/deberta_vocab.rs
+++ b/main/src/vocab/deberta_vocab.rs
@@ -48,6 +48,58 @@ pub struct DeBERTaVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "[UNK]";
+const DEFAULT_PAD_TOKEN: &str = "[PAD]";
+const DEFAULT_BOS_TOKEN: &str = "[CLS]";
+const DEFAULT_SEP_TOKEN: &str = "[SEP]";
+const DEFAULT_CLS_TOKEN: &str = "[CLS]";
+const DEFAULT_EOS_TOKEN: &str = "[SEP]";
+const DEFAULT_MASK_TOKEN: &str = "[MASK]";
+
+impl DeBERTaVocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+}
+
 impl Vocab for DeBERTaVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -73,13 +125,13 @@ impl Vocab for DeBERTaVocab {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "[UNK]".to_string(),
-            pad_token: Some("[PAD]".to_string()),
-            bos_token: Some("[CLS]".to_string()),
-            sep_token: Some("[SEP]".to_string()),
-            cls_token: Some("[CLS]".to_string()),
-            eos_token: Some("[SEP]".to_string()),
-            mask_token: Some("[MASK]".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/deberta_vocab.rs
+++ b/main/src/vocab/deberta_vocab.rs
@@ -150,7 +150,7 @@ impl Vocab for DeBERTaVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -16,12 +16,8 @@ use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
     read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 
 /// # FNetVocab
 /// Vocabulary for FNet tokenizer. Contains the following special values:
@@ -118,17 +114,41 @@ impl Vocab for FNetVocab {
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
         Self::from_values_and_special_token_map(values, special_token_map)
     }
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
 
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -47,25 +47,39 @@ pub struct FNetVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_SEP_TOKEN: &str = "[SEP]";
+const DEFAULT_CLS_TOKEN: &str = "[CLS]";
+const DEFAULT_MASK_TOKEN: &str = "[MASK]";
+
 impl FNetVocab {
-    /// Returns the SEP token for FNet (`[SEP]`)
-    pub fn sep_value() -> &'static str {
-        "[SEP]"
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
     }
 
-    /// Returns the CLS token for FNet (`[CLS]`)
-    pub fn cls_value() -> &'static str {
-        "[CLS]"
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
     }
 
-    /// Returns the MASK token for FNet (`[MASK]`)
-    pub fn mask_value() -> &'static str {
-        "[MASK]"
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
     }
 
-    /// Returns the PAD token for FNet (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
     }
 }
 
@@ -94,13 +108,13 @@ impl Vocab for FNetVocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
-            sep_token: Some("[SEP]".to_string()),
-            cls_token: Some("[CLS]".to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
             eos_token: None,
-            mask_token: Some("[MASK]".to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -133,7 +133,7 @@ impl Vocab for FNetVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -91,7 +91,7 @@ impl Vocab for FNetVocab {
     }
 
     fn from_file(path: &str) -> Result<FNetVocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -142,6 +142,7 @@ mod tests {
         let values: HashMap<String, i64> = HashMap::new();
         let special_values: HashMap<String, i64> = HashMap::new();
         let indices: HashMap<i64, String> = HashMap::new();
+        let special_indices: HashMap<i64, String> = HashMap::new();
         let special_token_map = SpecialTokenMap {
             unk_token: "<|endoftext|>".to_string(),
             pad_token: None,
@@ -164,8 +165,14 @@ mod tests {
 
         // Then
         assert_eq!(gpt2_vocab.get_unknown_value(), "<|endoftext|>");
-        assert_eq!(gpt2_vocab.special_token_map.bos_token, "<|endoftext|>");
-        assert_eq!(gpt2_vocab.special_token_map.eos_token, "<|endoftext|>");
+        assert_eq!(
+            gpt2_vocab.special_token_map.bos_token.as_ref().unwrap(),
+            "<|endoftext|>"
+        );
+        assert_eq!(
+            gpt2_vocab.special_token_map.eos_token.as_ref().unwrap(),
+            "<|endoftext|>"
+        );
         assert_eq!(gpt2_vocab.values, *gpt2_vocab.values());
         assert_eq!(gpt2_vocab.special_values, *gpt2_vocab.special_values());
     }

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -113,7 +113,7 @@ impl Vocab for Gpt2Vocab {
             token,
             &self.values,
             &self.special_values,
-            &self.get_unknown_value(),
+            self.get_unknown_value(),
         )
     }
 
@@ -122,7 +122,7 @@ impl Vocab for Gpt2Vocab {
             id,
             &self.indices,
             &self.special_indices,
-            &self.get_unknown_value(),
+            self.get_unknown_value(),
         )
     }
 }

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -113,7 +113,7 @@ impl Vocab for Gpt2Vocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -43,6 +43,26 @@ pub struct Gpt2Vocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<|endoftext|>";
+const DEFAULT_BOS_TOKEN: &str = DEFAULT_UNK_TOKEN;
+const DEFAULT_EOS_TOKEN: &str = DEFAULT_UNK_TOKEN;
+
+impl Gpt2Vocab {
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+}
+
 impl Vocab for Gpt2Vocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -68,12 +88,12 @@ impl Vocab for Gpt2Vocab {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<|endoftext|>".to_string(),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
             pad_token: None,
-            bos_token: Some("<|endoftext|>".to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
             sep_token: None,
             cls_token: None,
-            eos_token: Some("<|endoftext|>".to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
             mask_token: None,
             additional_special_tokens: None,
         };

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -60,6 +60,42 @@ pub struct M2M100Vocab {
     pub language_codes_bytes: HashSet<Vec<u8>>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_BOS_TOKEN: &str = "<s>";
+const DEFAULT_SEP_TOKEN: &str = "</s>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+
+impl M2M100Vocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+}
+
 impl Vocab for M2M100Vocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -85,12 +121,12 @@ impl Vocab for M2M100Vocab {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
-            bos_token: Some("<s>".to_string()),
-            sep_token: Some("</s>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
             cls_token: None,
-            eos_token: Some("</s>".to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
             mask_token: None,
             additional_special_tokens: None,
         };

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -82,7 +82,7 @@ impl Vocab for M2M100Vocab {
     }
 
     fn from_file(path: &str) -> Result<M2M100Vocab, TokenizerError> {
-        let mut values = read_json_file(path)?;
+        let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -174,7 +174,6 @@ impl Vocab for M2M100Vocab {
             })
             .collect::<HashSet<Vec<u8>>>();
 
-        let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;
 
         let indices = swap_key_values(&values);

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -17,8 +17,6 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::BufReader;
 
 pub static FAIRSEQ_LANGUAGE_CODES: [&str; 100] = [
     "af", "am", "ar", "ast", "az", "ba", "be", "bg", "bn", "br", "bs", "ca", "ceb", "cs", "cy",
@@ -161,11 +159,16 @@ impl Vocab for M2M100Vocab {
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::Vocab;
 use std::collections::HashMap;
 use std::fs::File;
@@ -33,8 +35,8 @@ pub struct MarianVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask
@@ -45,25 +47,9 @@ pub struct MarianVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
-impl MarianVocab {
-    /// Returns the PAD token for Marian (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
-    }
-
-    /// Returns the EOS token for Marian (`</s>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
-    }
-}
-
 impl Vocab for MarianVocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -83,37 +69,28 @@ impl Vocab for MarianVocab {
     }
 
     fn from_file(path: &str) -> Result<MarianVocab, TokenizerError> {
-        let f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let br = BufReader::new(f);
-        let values: HashMap<String, i64> = match serde_json::from_reader(br) {
-            Ok(value) => value,
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
+        let mut values = read_protobuf_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: Some("<pad>".to_string()),
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: Some("</s>".to_string()),
+            mask_token: None,
+            additional_special_tokens: None,
         };
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let mut special_values = HashMap::new();
-        let unknown_value = MarianVocab::unknown_value();
-        MarianVocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
-
-        let pad_value = MarianVocab::pad_value();
-        MarianVocab::_register_as_special_value(pad_value, &values, &mut special_values)?;
-
-        let eos_value = MarianVocab::eos_value();
-        MarianVocab::_register_as_special_value(eos_value, &values, &mut special_values)?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(MarianVocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_protobuf_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -45,6 +45,26 @@ pub struct MarianVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+
+impl MarianVocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+}
+
 impl Vocab for MarianVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -70,12 +90,12 @@ impl Vocab for MarianVocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
             sep_token: None,
             cls_token: None,
-            eos_token: Some("</s>".to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
             mask_token: None,
             additional_special_tokens: None,
         };

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -18,8 +18,6 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
 
 /// # Marian Vocab
 /// Vocabulary for Marian tokenizer. Contains the following special values:
@@ -92,17 +90,41 @@ impl Vocab for MarianVocab {
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
         Self::from_values_and_special_token_map(values, special_token_map)
     }
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
 
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -14,7 +14,7 @@
 
 use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
-    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+    read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
@@ -87,7 +87,7 @@ impl Vocab for MarianVocab {
     }
 
     fn from_file(path: &str) -> Result<MarianVocab, TokenizerError> {
-        let values = read_protobuf_file(path)?;
+        let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: DEFAULT_UNK_TOKEN.to_string(),
@@ -106,7 +106,7 @@ impl Vocab for MarianVocab {
         path: &str,
         special_token_mapping_path: &str,
     ) -> Result<Self, TokenizerError> {
-        let values = read_protobuf_file(path)?;
+        let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
         Self::from_values_and_special_token_map(values, special_token_map)
     }
@@ -115,7 +115,7 @@ impl Vocab for MarianVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -67,7 +67,7 @@ impl Vocab for MarianVocab {
     }
 
     fn from_file(path: &str) -> Result<MarianVocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -125,7 +125,7 @@ impl Vocab for MBart50Vocab {
             values.len() as i64,
         );
 
-        special_token_map.register_special_values(&values, &mut special_values);
+        let _ = special_token_map.register_special_values(&values, &mut special_values);
 
         let indices = swap_key_values(&values);
         let special_indices = swap_key_values(&special_values);
@@ -182,7 +182,7 @@ impl Vocab for MBart50Vocab {
             values.len() as i64,
         );
 
-        special_token_map.register_special_values(&values, &mut special_values);
+        let _ = special_token_map.register_special_values(&values, &mut special_values);
 
         let indices = swap_key_values(&values);
         let special_indices = swap_key_values(&special_values);

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -60,6 +60,50 @@ pub struct MBart50Vocab {
     pub language_codes_bytes: HashSet<Vec<u8>>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_SEP_TOKEN: &str = "</s>";
+const DEFAULT_CLS_TOKEN: &str = "<s>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+const DEFAULT_MASK_TOKEN: &str = "<mask>";
+
+impl MBart50Vocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+}
+
 impl Vocab for MBart50Vocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -86,16 +130,15 @@ impl Vocab for MBart50Vocab {
         let mut special_values = HashMap::new();
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
-            sep_token: Some("</s>".to_string()),
-            cls_token: Some("<s>".to_string()),
-            eos_token: Some("</s>".to_string()),
-            mask_token: Some("<mask>".to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
-
         values.insert(
             special_token_map.cls_token.as_ref().unwrap().clone(),
             values.len() as i64,

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -15,9 +15,7 @@ use crate::vocab::base_vocab::{
     open_protobuf_file, read_special_token_mapping_file, register_as_special_value,
     swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::{HashMap, HashSet};
 
 pub static FAIRSEQ_LANGUAGE_CODES: [&str; 52] = [
@@ -203,16 +201,48 @@ impl Vocab for MBart50Vocab {
         })
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+
+        let language_codes_bytes = FAIRSEQ_LANGUAGE_CODES
+            .iter()
+            .map(|f| f.as_bytes().to_vec())
+            .collect::<HashSet<Vec<u8>>>();
+
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+            language_codes_bytes,
+        })
+    }
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -249,7 +249,7 @@ impl Vocab for MBart50Vocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -12,14 +12,13 @@
 
 use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
-    read_special_token_mapping_file, register_as_special_value, swap_key_values, SpecialTokenMap,
+    open_protobuf_file, read_special_token_mapping_file, register_as_special_value,
+    swap_key_values, SpecialTokenMap,
 };
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::Read;
 
 pub static FAIRSEQ_LANGUAGE_CODES: [&str; 52] = [
     ">>ar<<", ">>cs<<", ">>de<<", ">>en<<", ">>es<<", ">>et<<", ">>fi<<", ">>fr<<", ">>gu<<",
@@ -113,21 +112,7 @@ impl Vocab for MBart50Vocab {
         );
         values.insert(special_token_map.unk_token.clone(), values.len() as i64);
 
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
-        };
+        let proto = open_protobuf_file(path)?;
         for piece in proto.get_pieces().iter().skip(3) {
             values.insert(piece.get_piece().to_owned(), values.len() as i64);
         }
@@ -184,21 +169,7 @@ impl Vocab for MBart50Vocab {
 
         values.insert(special_token_map.unk_token.clone(), values.len() as i64);
 
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
-        };
+        let proto = open_protobuf_file(path)?;
         for piece in proto.get_pieces().iter().skip(3) {
             values.insert(piece.get_piece().to_owned(), values.len() as i64);
         }

--- a/main/src/vocab/mod.rs
+++ b/main/src/vocab/mod.rs
@@ -60,7 +60,7 @@ pub use albert_vocab::AlbertVocab;
 pub use base_vocab::{BaseVocab, Vocab};
 pub use bert_vocab::BertVocab;
 pub use bpe_vocab::{BpePairRef, BpePairVocab};
-pub use deberta_v2_vocab::DeBERTaV2Vocab;
+pub use deberta_v2_vocab::{DeBERTaV2SpecialTokensMap, DeBERTaV2Vocab};
 pub use deberta_vocab::DeBERTaVocab;
 pub use fnet_vocab::FNetVocab;
 pub use gpt2_vocab::Gpt2Vocab;

--- a/main/src/vocab/mod.rs
+++ b/main/src/vocab/mod.rs
@@ -60,7 +60,7 @@ pub use albert_vocab::AlbertVocab;
 pub use base_vocab::{BaseVocab, Vocab};
 pub use bert_vocab::BertVocab;
 pub use bpe_vocab::{BpePairRef, BpePairVocab};
-pub use deberta_v2_vocab::{DeBERTaV2SpecialTokensMap, DeBERTaV2Vocab};
+pub use deberta_v2_vocab::DeBERTaV2Vocab;
 pub use deberta_vocab::DeBERTaVocab;
 pub use fnet_vocab::FNetVocab;
 pub use gpt2_vocab::Gpt2Vocab;

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -198,7 +198,7 @@ mod tests {
         let openai_gpt_vocab = OpenAiGptVocab::from_file(path.to_path_buf().to_str().unwrap())?;
 
         //        Then
-        assert_eq!(openai_gpt_vocab.unknown_value, "<unk>");
+        assert_eq!(openai_gpt_vocab.get_unknown_value(), "<unk>");
         assert_eq!(openai_gpt_vocab.values, target_values);
         assert_eq!(openai_gpt_vocab.special_values, special_values);
         drop(path);

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -40,6 +40,8 @@ pub struct OpenAiGptVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+
 impl Vocab for OpenAiGptVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -65,7 +67,7 @@ impl Vocab for OpenAiGptVocab {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
             pad_token: None,
             bos_token: None,
             sep_token: None,

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -93,7 +93,7 @@ impl Vocab for OpenAiGptVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -16,8 +16,6 @@ use crate::vocab::base_vocab::{
     read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
 
 /// # GPT Vocab
 /// Vocabulary for GPT tokenizer. Only contains the unknown token as a special value.
@@ -88,17 +86,43 @@ impl Vocab for OpenAiGptVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }
 

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -28,8 +28,8 @@ pub struct OpenAiGptVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -36,8 +36,8 @@ pub struct PegasusVocab {
     /// A mapping of token IDs to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -294,7 +294,7 @@ impl Vocab for PegasusVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -47,7 +47,34 @@ pub struct PegasusVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+const DEFAULT_MASK_TOKEN: &str = "<mask_2>";
+const DEFAULT_SENTENCE_MASK_TOKEN: &str = "<mask_1>";
+
 impl PegasusVocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+
     fn _add_and_register_special_value(
         values: &mut HashMap<String, i64>,
         special_values: &mut HashMap<String, i64>,
@@ -87,19 +114,19 @@ impl Vocab for PegasusVocab {
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();
 
-        let mut additional_special_tokens = HashSet::from(["<mask_1>".into()]);
+        let mut additional_special_tokens = HashSet::from([DEFAULT_SENTENCE_MASK_TOKEN.into()]);
         for idx in 2..103 {
             let _ = additional_special_tokens.insert(format!("<unk_{}>", idx));
         }
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
             sep_token: None,
             cls_token: None,
-            eos_token: Some("</s>".to_string()),
-            mask_token: Some("<mask_2>".to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: Some(additional_special_tokens),
         };
 

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -11,12 +11,15 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    open_protobuf_file, read_special_token_mapping_file, register_as_special_value,
+    swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 
@@ -49,28 +52,6 @@ pub struct PegasusVocab {
 }
 
 impl PegasusVocab {
-    /// Returns the EOS token for Pegasus (`</s>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
-    }
-
-    /// Returns the MASK token for Pegasus (`<mask_2>`)
-    pub fn mask_value() -> &'static str {
-        "<mask_2>"
-    }
-
-    /// Returns the MASK token for Pegasus (`<mask_1>`)
-    pub fn mask_sent_value() -> &'static str {
-        "<mask_1>"
-    }
-
-    /// Returns the PAD token for Pegasus (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
-    }
-}
-
-impl PegasusVocab {
     fn _add_and_register_special_value(
         values: &mut HashMap<String, i64>,
         special_values: &mut HashMap<String, i64>,
@@ -78,18 +59,14 @@ impl PegasusVocab {
         offset: i64,
     ) -> Result<i64, TokenizerError> {
         values.insert(value.to_string(), offset as i64);
-        PegasusVocab::_register_as_special_value(value, values, special_values)?;
+        register_as_special_value(value, values, special_values)?;
         Ok(offset + 1)
     }
 }
 
 impl Vocab for PegasusVocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -109,30 +86,32 @@ impl Vocab for PegasusVocab {
     }
 
     fn from_file(path: &str) -> Result<PegasusVocab, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
-        };
+        let proto = open_protobuf_file(path)?;
 
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();
+
+        let mut additional_special_tokens = HashSet::from(["<mask_1>".into()]);
+        for idx in 2..103 {
+            let _ = additional_special_tokens.insert(format!("<unk_{}>", idx));
+        }
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: Some("<pad>".to_string()),
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: Some("</s>".to_string()),
+            mask_token: Some("<mask_2>".to_string()),
+            additional_special_tokens: Some(additional_special_tokens),
+        };
 
         // Insert special tokens (not contained in SentencePiece proto)
         let mut offset = 0_i64;
 
         // pad value
-        let pad_value = PegasusVocab::pad_value();
+        let pad_value = special_token_map.pad_token.as_ref().unwrap();
         offset = PegasusVocab::_add_and_register_special_value(
             &mut values,
             &mut special_values,
@@ -141,7 +120,7 @@ impl Vocab for PegasusVocab {
         )?;
 
         // EOS value
-        let eos_value = PegasusVocab::eos_value();
+        let eos_value = special_token_map.eos_token.as_ref().unwrap();
         offset = PegasusVocab::_add_and_register_special_value(
             &mut values,
             &mut special_values,
@@ -150,7 +129,7 @@ impl Vocab for PegasusVocab {
         )?;
 
         // Mask value
-        let mask_value = PegasusVocab::mask_value();
+        let mask_value = special_token_map.mask_token.as_ref().unwrap();
         offset = PegasusVocab::_add_and_register_special_value(
             &mut values,
             &mut special_values,
@@ -158,22 +137,16 @@ impl Vocab for PegasusVocab {
             offset,
         )?;
 
-        // Sentence mask value
-        let mask_sent_value = PegasusVocab::mask_sent_value();
-        offset = PegasusVocab::_add_and_register_special_value(
-            &mut values,
-            &mut special_values,
-            mask_sent_value,
-            offset,
-        )?;
-
-        // Reserved additional special tokens
-        for idx in 2..103 {
-            let add_unk_token = format!("<unk_{}>", idx);
+        // Sentence mask value & additional tokens
+        for additional_token in special_token_map
+            .additional_special_tokens
+            .as_ref()
+            .unwrap()
+        {
             offset = PegasusVocab::_add_and_register_special_value(
                 &mut values,
                 &mut special_values,
-                add_unk_token.as_str(),
+                additional_token,
                 offset,
             )?;
         }
@@ -191,8 +164,7 @@ impl Vocab for PegasusVocab {
             };
         }
 
-        let unknown_value = PegasusVocab::unknown_value();
-        PegasusVocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
+        register_as_special_value(&special_token_map.unk_token, &values, &mut special_values)?;
 
         let indices = swap_key_values(&values);
         let special_indices = swap_key_values(&special_values);
@@ -200,7 +172,95 @@ impl Vocab for PegasusVocab {
         Ok(PegasusVocab {
             values,
             indices,
-            unknown_value,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let proto = open_protobuf_file(path)?;
+
+        let mut values = HashMap::new();
+        let mut special_values = HashMap::new();
+
+        let mut additional_special_tokens = HashSet::from(["<mask_1>".into()]);
+        for idx in 2..103 {
+            let _ = additional_special_tokens.insert(format!("<unk_{}>", idx));
+        }
+
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+
+        // Insert special tokens (not contained in SentencePiece proto)
+        let mut offset = 0_i64;
+
+        // pad value
+        if let Some(pad_value) = &special_token_map.pad_token {
+            offset = PegasusVocab::_add_and_register_special_value(
+                &mut values,
+                &mut special_values,
+                pad_value,
+                offset,
+            )?;
+        }
+
+        // EOS value
+        if let Some(eos_value) = &special_token_map.eos_token {
+            offset = PegasusVocab::_add_and_register_special_value(
+                &mut values,
+                &mut special_values,
+                eos_value,
+                offset,
+            )?;
+        }
+
+        // Mask value
+        if let Some(mask_value) = &special_token_map.mask_token {
+            offset = PegasusVocab::_add_and_register_special_value(
+                &mut values,
+                &mut special_values,
+                mask_value,
+                offset,
+            )?;
+        }
+
+        // Sentence mask value & additional tokens
+        if let Some(additional_tokens) = &special_token_map.additional_special_tokens {
+            for additional_token in additional_tokens {
+                offset = PegasusVocab::_add_and_register_special_value(
+                    &mut values,
+                    &mut special_values,
+                    additional_token,
+                    offset,
+                )?;
+            }
+        }
+
+        let mut current_piece: String;
+        let mut idx = 0;
+        for piece in proto.get_pieces().iter() {
+            current_piece = piece.get_piece().to_owned();
+            match values.entry(current_piece) {
+                Entry::Vacant(v) => {
+                    v.insert(idx as i64 + offset);
+                    idx += 1;
+                }
+                Entry::Occupied(_) => {}
+            };
+        }
+
+        register_as_special_value(&special_token_map.unk_token, &values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+
+        Ok(PegasusVocab {
+            values,
+            indices,
+            special_token_map,
             special_values,
             special_indices,
         })

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -15,13 +15,9 @@ use crate::vocab::base_vocab::{
     open_protobuf_file, read_special_token_mapping_file, register_as_special_value,
     swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::Read;
 
 /// # Pegasus Vocab
 /// Vocabulary for Pegasus tokenizer. Contains the following special values:
@@ -266,16 +262,42 @@ impl Vocab for PegasusVocab {
         })
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -77,7 +77,7 @@ impl Vocab for ProphetNetVocab {
             cls_token: Some("[CLS]".to_string()),
             eos_token: None,
             mask_token: Some("[MASK]".to_string()),
-            additional_special_tokens: Some(HashSet::from(["[X_SEP".into()])),
+            additional_special_tokens: Some(HashSet::from(["[X_SEP]".into()])),
         };
 
         Self::from_values_and_special_token_map(values, special_token_map)
@@ -200,6 +200,7 @@ mod tests {
 
         let special_values: HashMap<String, i64> = [
             ("[UNK]".to_owned(), 2),
+            ("[X_SEP]".to_owned(), 4),
             ("[SEP]".to_owned(), 5),
             ("[MASK]".to_owned(), 6),
             ("[PAD]".to_owned(), 7),

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -45,6 +45,43 @@ pub struct ProphetNetVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "[UNK]";
+const DEFAULT_PAD_TOKEN: &str = "[PAD]";
+const DEFAULT_SEP_TOKEN: &str = "[SEP]";
+const DEFAULT_X_SEP_TOKEN: &str = "[X_SEP]";
+const DEFAULT_CLS_TOKEN: &str = "[CLS]";
+const DEFAULT_MASK_TOKEN: &str = "[MASK]";
+
+impl ProphetNetVocab {
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
+    }
+}
+
 impl Vocab for ProphetNetVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -70,14 +107,14 @@ impl Vocab for ProphetNetVocab {
         let values = read_flat_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "[UNK]".to_string(),
-            pad_token: Some("[PAD]".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
-            sep_token: Some("[SEP]".to_string()),
-            cls_token: Some("[CLS]".to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
             eos_token: None,
-            mask_token: Some("[MASK]".to_string()),
-            additional_special_tokens: Some(HashSet::from(["[X_SEP]".into()])),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
+            additional_special_tokens: Some(HashSet::from([DEFAULT_X_SEP_TOKEN.into()])),
         };
 
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -134,7 +134,7 @@ impl Vocab for ProphetNetVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -31,8 +31,8 @@ pub struct ProphetNetVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -92,17 +92,43 @@ impl Vocab for ProphetNetVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }
 

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -65,7 +65,7 @@ impl Vocab for ReformerVocab {
     }
 
     fn from_file(path: &str) -> Result<ReformerVocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),
@@ -73,7 +73,7 @@ impl Vocab for ReformerVocab {
             bos_token: None,
             sep_token: None,
             cls_token: None,
-            eos_token: Some("</s".to_string()),
+            eos_token: Some("</s>".to_string()),
             mask_token: None,
             additional_special_tokens: None,
         };

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -43,6 +43,18 @@ pub struct ReformerVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+
+impl ReformerVocab {
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+}
+
 impl Vocab for ReformerVocab {
     fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
@@ -68,12 +80,12 @@ impl Vocab for ReformerVocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
             pad_token: None,
             bos_token: None,
             sep_token: None,
             cls_token: None,
-            eos_token: Some("</s>".to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
             mask_token: None,
             additional_special_tokens: None,
         };

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -12,7 +12,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
@@ -45,20 +47,9 @@ pub struct ReformerVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
-impl ReformerVocab {
-    /// Returns the EOS token for the Reformer (`</s>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
-    }
-}
-
 impl Vocab for ReformerVocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -78,44 +69,28 @@ impl Vocab for ReformerVocab {
     }
 
     fn from_file(path: &str) -> Result<ReformerVocab, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
+        let mut values = read_protobuf_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: None,
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: Some("</s".to_string()),
+            mask_token: None,
+            additional_special_tokens: None,
         };
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let mut values = HashMap::new();
-        for (idx, piece) in proto.get_pieces().iter().enumerate() {
-            values.insert(piece.get_piece().to_owned(), idx as i64);
-        }
-
-        let mut special_values = HashMap::new();
-        let unknown_value = ReformerVocab::unknown_value();
-        ReformerVocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
-
-        let eos_value = ReformerVocab::eos_value();
-        ReformerVocab::_register_as_special_value(eos_value, &values, &mut special_values)?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(ReformerVocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_protobuf_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -33,8 +33,8 @@ pub struct ReformerVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -15,12 +15,8 @@ use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
     read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 
 /// # ReformerVocab
 /// Vocabulary for reformer tokenizer. Contains the following special values:
@@ -93,16 +89,42 @@ impl Vocab for ReformerVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -106,7 +106,7 @@ impl Vocab for ReformerVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -247,7 +247,7 @@ mod tests {
         let roberta_vocab = RobertaVocab::from_file(path.to_path_buf().to_str().unwrap())?;
 
         //        Then
-        assert_eq!(roberta_vocab.unknown_value, "<unk>");
+        assert_eq!(roberta_vocab.get_unknown_value(), "<unk>");
         assert_eq!(roberta_vocab.values, target_values);
         assert_eq!(roberta_vocab.special_values, special_values);
         drop(path);

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -47,35 +47,55 @@ pub struct RobertaVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_BOS_TOKEN: &str = "<s>";
+const DEFAULT_SEP_TOKEN: &str = "</s>";
+const DEFAULT_CLS_TOKEN: &str = "<s>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+const DEFAULT_MASK_TOKEN: &str = "<mask>";
+
 impl RobertaVocab {
-    /// Returns the PAD token for RoBERTa (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
     }
 
-    /// Returns the BOS token for RoBERTa (`<s>`)
-    pub fn bos_value() -> &'static str {
-        "<s>"
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
     }
 
-    /// Returns the EOS token for RoBERTa (`</s>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
     }
 
-    /// Returns the SEP token for RoBERTa (`</s>`)
-    pub fn sep_value() -> &'static str {
-        "</s>"
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
     }
 
-    /// Returns the CLS token for RoBERTa (`<s>`)
-    pub fn cls_value() -> &'static str {
-        "<s>"
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
     }
 
-    /// Returns the MASK token for RoBERTa (`<mask>`)
-    pub fn mask_value() -> &'static str {
-        "<mask>"
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
     }
 }
 
@@ -105,13 +125,13 @@ impl Vocab for RobertaVocab {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
-            bos_token: Some("<s>".to_string()),
-            sep_token: Some("</s>".to_string()),
-            cls_token: Some("<s>".to_string()),
-            eos_token: Some("</s>".to_string()),
-            mask_token: Some("<mask>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -151,7 +151,7 @@ impl Vocab for RobertaVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -12,7 +12,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::{swap_key_values, Vocab};
+use crate::vocab::base_vocab::{
+    read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
+};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
@@ -80,12 +82,8 @@ impl RobertaVocab {
 }
 
 impl Vocab for RobertaVocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -106,48 +104,28 @@ impl Vocab for RobertaVocab {
 
     ///Read a Roberta-style vocab.json file
     fn from_file(path: &str) -> Result<RobertaVocab, TokenizerError> {
-        let f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let br = BufReader::new(f);
-        let values: HashMap<String, i64> = match serde_json::from_reader(br) {
-            Ok(value) => value,
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
+        let values = read_json_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: Some("<pad>".to_string()),
+            bos_token: Some("<s>".to_string()),
+            sep_token: Some("</s>".to_string()),
+            cls_token: Some("<s>".to_string()),
+            eos_token: Some("</s>".to_string()),
+            mask_token: Some("<mask>".to_string()),
+            additional_special_tokens: None,
         };
-        let mut special_values = HashMap::new();
-        let unknown_value = RobertaVocab::unknown_value();
-        RobertaVocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let pad_value = RobertaVocab::pad_value();
-        RobertaVocab::_register_as_special_value(pad_value, &values, &mut special_values)?;
-
-        let sep_value = RobertaVocab::sep_value();
-        RobertaVocab::_register_as_special_value(sep_value, &values, &mut special_values)?;
-
-        let cls_value = RobertaVocab::cls_value();
-        RobertaVocab::_register_as_special_value(cls_value, &values, &mut special_values)?;
-
-        let mask_value = RobertaVocab::mask_value();
-        RobertaVocab::_register_as_special_value(mask_value, &values, &mut special_values)?;
-
-        let bos_value = RobertaVocab::bos_value();
-        RobertaVocab::_register_as_special_value(bos_value, &values, &mut special_values)?;
-
-        let eos_value = RobertaVocab::eos_value();
-        RobertaVocab::_register_as_special_value(eos_value, &values, &mut special_values)?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(RobertaVocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_json_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -35,8 +35,8 @@ pub struct RobertaVocab {
     /// A mapping of token IDs to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -37,8 +37,8 @@ pub struct SentencePieceVocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -14,12 +14,8 @@ use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
     read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 
 /// # SentencePieceVocab
 /// Vocabulary for SentencePiece model/tokenizer. Contains the following special values:
@@ -129,16 +125,42 @@ impl Vocab for SentencePieceVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -18,13 +18,7 @@ use crate::vocab::Vocab;
 use std::collections::HashMap;
 
 /// # SentencePieceVocab
-/// Vocabulary for SentencePiece model/tokenizer. Contains the following special values:
-/// - BOS token
-/// - EOS token
-/// - CLS token
-/// - SEP token
-/// - PAD token
-/// - MASK token
+/// Vocabulary for SentencePiece model/tokenizer.
 ///
 /// Expects a SentencePiece protobuf file when created from file.
 #[derive(Debug, Clone)]
@@ -47,37 +41,7 @@ pub struct SentencePieceVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
-impl SentencePieceVocab {
-    /// Returns the PAD token for SentencePiece (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
-    }
-
-    /// Returns the SEP token for SentencePiece (`<sep>`)
-    pub fn sep_value() -> &'static str {
-        "<sep>"
-    }
-
-    /// Returns the CLS token for SentencePiece (`<cls>`)
-    pub fn cls_value() -> &'static str {
-        "<cls>"
-    }
-
-    /// Returns the MASK token for SentencePiece (`<mask>`)
-    pub fn mask_value() -> &'static str {
-        "<mask>"
-    }
-
-    /// Returns the BOS token for SentencePiece (`<s>`)
-    pub fn bos_value() -> &'static str {
-        "<s>"
-    }
-
-    /// Returns the EOS token for SentencePiece (`</s>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
-    }
-}
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
 
 impl Vocab for SentencePieceVocab {
     fn get_unknown_value(&self) -> &str {
@@ -104,7 +68,7 @@ impl Vocab for SentencePieceVocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
             pad_token: None,
             bos_token: None,
             sep_token: None,

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -94,7 +94,7 @@ impl Vocab for SentencePieceVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -101,7 +101,7 @@ impl Vocab for SentencePieceVocab {
     }
 
     fn from_file(path: &str) -> Result<SentencePieceVocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -11,7 +11,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
@@ -82,12 +84,8 @@ impl SentencePieceVocab {
 }
 
 impl Vocab for SentencePieceVocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -107,51 +105,28 @@ impl Vocab for SentencePieceVocab {
     }
 
     fn from_file(path: &str) -> Result<SentencePieceVocab, TokenizerError> {
-        let mut f = match File::open(path) {
-            Ok(file) => file,
-            Err(_) => {
-                return Err(TokenizerError::FileNotFound(format!(
-                    "{} vocabulary file not found",
-                    path
-                )));
-            }
+        let mut values = read_protobuf_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: None,
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: None,
+            mask_token: None,
+            additional_special_tokens: None,
         };
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
-        };
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let mut values = HashMap::new();
-        for (idx, piece) in proto.get_pieces().iter().enumerate() {
-            values.insert(piece.get_piece().to_owned(), idx as i64);
-        }
-
-        let mut special_values = HashMap::new();
-        let unknown_value = SentencePieceVocab::unknown_value();
-        SentencePieceVocab::_register_as_special_value(
-            unknown_value,
-            &values,
-            &mut special_values,
-        )?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(SentencePieceVocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_protobuf_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -11,7 +11,9 @@
 // limitations under the License.
 
 use crate::error::TokenizerError;
-use crate::vocab::base_vocab::swap_key_values;
+use crate::vocab::base_vocab::{
+    read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
+};
 use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
 use protobuf::Message;
@@ -58,12 +60,8 @@ impl T5Vocab {
 }
 
 impl Vocab for T5Vocab {
-    fn unknown_value() -> &'static str {
-        "<unk>"
-    }
-
-    fn get_unknown_value(&self) -> &'static str {
-        "<unk>"
+    fn get_unknown_value(&self) -> &str {
+        &self.special_token_map.unk_token
     }
 
     fn values(&self) -> &HashMap<String, i64> {
@@ -83,46 +81,28 @@ impl Vocab for T5Vocab {
     }
 
     fn from_file(path: &str) -> Result<T5Vocab, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
-        })?;
-        let mut contents = Vec::new();
-        let proto = match f.read_to_end(&mut contents) {
-            Ok(_) => match ModelProto::parse_from_bytes(contents.as_slice()) {
-                Ok(proto_value) => proto_value,
-                Err(e) => {
-                    return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-                }
-            },
-            Err(e) => {
-                return Err(TokenizerError::VocabularyParsingError(e.to_string()));
-            }
+        let mut values = read_protobuf_file(path)?;
+
+        let special_token_map = SpecialTokenMap {
+            unk_token: "<unk>".to_string(),
+            pad_token: Some("<pad>".to_string()),
+            bos_token: None,
+            sep_token: None,
+            cls_token: None,
+            eos_token: Some("</s>".to_string()),
+            mask_token: None,
+            additional_special_tokens: None,
         };
-        let mut values = HashMap::new();
-        for (idx, piece) in proto.get_pieces().iter().enumerate() {
-            values.insert(piece.get_piece().to_owned(), idx as i64);
-        }
+        Self::from_values_and_special_token_map(values, special_token_map)
+    }
 
-        let mut special_values = HashMap::new();
-        let unknown_value = T5Vocab::unknown_value();
-        T5Vocab::_register_as_special_value(unknown_value, &values, &mut special_values)?;
-
-        let eos_value = T5Vocab::eos_value();
-        T5Vocab::_register_as_special_value(eos_value, &values, &mut special_values)?;
-
-        let pad_value = T5Vocab::pad_value();
-        T5Vocab::_register_as_special_value(pad_value, &values, &mut special_values)?;
-
-        let indices = swap_key_values(&values);
-        let special_indices = swap_key_values(&special_values);
-
-        Ok(T5Vocab {
-            values,
-            indices,
-            unknown_value,
-            special_values,
-            special_indices,
-        })
+    fn from_file_with_special_token_mapping(
+        path: &str,
+        special_token_mapping_path: &str,
+    ) -> Result<Self, TokenizerError> {
+        let values = read_protobuf_file(path)?;
+        let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
+        Self::from_values_and_special_token_map(values, special_token_map)
     }
 
     fn token_to_id(&self, token: &str) -> i64 {

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -77,7 +77,7 @@ impl Vocab for T5Vocab {
     }
 
     fn from_file(path: &str) -> Result<T5Vocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -114,7 +114,7 @@ impl Vocab for T5Vocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -33,8 +33,8 @@ pub struct T5Vocab {
     /// A mapping of token ids to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -14,12 +14,8 @@ use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
     read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 
 /// # T5 Vocab
 /// Vocabulary for T5 tokenizer. Contains the following special values:
@@ -105,16 +101,42 @@ impl Vocab for T5Vocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -43,15 +43,23 @@ pub struct T5Vocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+
 impl T5Vocab {
-    /// Returns the EOS token for T5 (`<eos>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
     }
 
-    /// Returns the PAD token for T5 (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
     }
 }
 
@@ -80,12 +88,12 @@ impl Vocab for T5Vocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
             bos_token: None,
             sep_token: None,
             cls_token: None,
-            eos_token: Some("</s>".to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
             mask_token: None,
             additional_special_tokens: None,
         };

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -83,7 +83,7 @@ impl XLMRobertaVocab {
 }
 
 impl Vocab for XLMRobertaVocab {
-    fn get_unknown_value(&self) -> &'static str {
+    fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
     }
 

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -259,7 +259,7 @@ impl Vocab for XLMRobertaVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -39,8 +39,8 @@ pub struct XLMRobertaVocab {
     /// A mapping of token IDs to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -50,35 +50,55 @@ pub struct XLMRobertaVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_BOS_TOKEN: &str = "<s>";
+const DEFAULT_SEP_TOKEN: &str = "</s>";
+const DEFAULT_CLS_TOKEN: &str = "<s>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+const DEFAULT_MASK_TOKEN: &str = "<mask>";
+
 impl XLMRobertaVocab {
-    /// Returns the BOS token for XLMRoBERTa (`<s>`)
-    pub fn bos_value() -> &'static str {
-        "<s>"
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
     }
 
-    /// Returns the EOS token for XLMRoBERTa (`</s>`)
-    pub fn eos_value() -> &'static str {
-        "</s>"
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
     }
 
-    /// Returns the SEP token for XLMRoBERTa (`</s>`)
-    pub fn sep_value() -> &'static str {
-        "</s>"
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
     }
 
-    /// Returns the CLS token for XLMRoBERTa (`<s>`)
-    pub fn cls_value() -> &'static str {
-        "<s>"
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
     }
 
-    /// Returns the MASK token for XLMRoBERTa (`<mask>`)
-    pub fn mask_value() -> &'static str {
-        "<mask>"
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
     }
 
-    /// Returns the PAD token for XLMRoBERTa (`<pad>`)
-    pub fn pad_value() -> &'static str {
-        "<pad>"
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
     }
 }
 
@@ -107,13 +127,13 @@ impl Vocab for XLMRobertaVocab {
         let proto = open_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
-            bos_token: Some("<s>".to_string()),
-            sep_token: Some("</s>".to_string()),
-            cls_token: Some("<s>".to_string()),
-            eos_token: Some("</s>".to_string()),
-            mask_token: Some("<mask>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: None,
         };
 
@@ -135,7 +155,7 @@ impl Vocab for XLMRobertaVocab {
             values.insert(piece.get_piece().to_owned(), values.len() as i64);
         }
         values.insert(
-            XLMRobertaVocab::mask_value().to_owned(),
+            special_token_map.mask_token.as_ref().unwrap().clone(),
             values.len() as i64,
         );
 
@@ -210,7 +230,7 @@ impl Vocab for XLMRobertaVocab {
             values.insert(piece.get_piece().to_owned(), values.len() as i64);
         }
         values.insert(
-            XLMRobertaVocab::mask_value().to_owned(),
+            special_token_map.cls_token.as_ref().unwrap().clone(),
             values.len() as i64,
         );
 

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -142,27 +142,27 @@ impl Vocab for XLMRobertaVocab {
         let mut special_values = HashMap::new();
         register_as_special_value(&special_token_map.unk_token, &values, &mut special_values)?;
         register_as_special_value(
-            &special_token_map.bos_token.as_ref().unwrap(),
+            special_token_map.bos_token.as_ref().unwrap(),
             &values,
             &mut special_values,
         )?;
         register_as_special_value(
-            &special_token_map.eos_token.as_ref().unwrap(),
+            special_token_map.eos_token.as_ref().unwrap(),
             &values,
             &mut special_values,
         )?;
         register_as_special_value(
-            &special_token_map.cls_token.as_ref().unwrap(),
+            special_token_map.cls_token.as_ref().unwrap(),
             &values,
             &mut special_values,
         )?;
         register_as_special_value(
-            &special_token_map.mask_token.as_ref().unwrap(),
+            special_token_map.mask_token.as_ref().unwrap(),
             &values,
             &mut special_values,
         )?;
         register_as_special_value(
-            &special_token_map.pad_token.as_ref().unwrap(),
+            special_token_map.pad_token.as_ref().unwrap(),
             &values,
             &mut special_values,
         )?;
@@ -192,17 +192,17 @@ impl Vocab for XLMRobertaVocab {
 
         if let Some(cls_token) = &special_token_map.cls_token {
             values.insert(cls_token.clone(), values.len() as i64);
-            register_as_special_value(&cls_token, &values, &mut special_values)?;
+            register_as_special_value(cls_token, &values, &mut special_values)?;
         }
 
         if let Some(pad_token) = &special_token_map.pad_token {
             values.insert(pad_token.clone(), values.len() as i64);
-            register_as_special_value(&pad_token, &values, &mut special_values)?;
+            register_as_special_value(pad_token, &values, &mut special_values)?;
         }
 
         if let Some(eos_token) = &special_token_map.eos_token {
             values.insert(eos_token.clone(), values.len() as i64);
-            register_as_special_value(&eos_token, &values, &mut special_values)?;
+            register_as_special_value(eos_token, &values, &mut special_values)?;
         }
 
         values.insert(special_token_map.unk_token.clone(), values.len() as i64);

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -40,8 +40,8 @@ pub struct XLNetVocab {
     /// A mapping of token IDs to strings (i.e. the decoder base)
     pub indices: HashMap<i64, String>,
 
-    /// The string to use for unknown (out of vocabulary) tokens
-    pub unknown_value: &'static str,
+    /// Special tokens used by the vocabulary
+    pub special_token_map: SpecialTokenMap,
 
     /// A mapping of special value tokens as strings to IDs (i.e. the encoder base for special
     /// values), special values typically include things like BOS/EOS markers, class markers, mask

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -63,7 +63,7 @@ impl XLNetVocab {
 }
 
 impl Vocab for XLNetVocab {
-    fn get_unknown_value(&self) -> &'static str {
+    fn get_unknown_value(&self) -> &str {
         &self.special_token_map.unk_token
     }
 
@@ -84,7 +84,7 @@ impl Vocab for XLNetVocab {
     }
 
     fn from_file(path: &str) -> Result<XLNetVocab, TokenizerError> {
-        let mut values = read_protobuf_file(path)?;
+        let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: "<unk>".to_string(),

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -50,15 +50,57 @@ pub struct XLNetVocab {
     pub special_indices: HashMap<i64, String>,
 }
 
+const DEFAULT_UNK_TOKEN: &str = "<unk>";
+const DEFAULT_PAD_TOKEN: &str = "<pad>";
+const DEFAULT_BOS_TOKEN: &str = "<s>";
+const DEFAULT_SEP_TOKEN: &str = "<sep>";
+const DEFAULT_CLS_TOKEN: &str = "<cls>";
+const DEFAULT_EOS_TOKEN: &str = "</s>";
+const DEFAULT_EOP_TOKEN: &str = "<eop>";
+const DEFAULT_EOD_TOKEN: &str = "<eod>";
+const DEFAULT_MASK_TOKEN: &str = "<mask>";
+
 impl XLNetVocab {
-    /// Returns the EOP token for XLNet (`<eop>`)
-    pub fn eop_value() -> &'static str {
-        "<eop>"
+    pub fn get_pad_value(&self) -> &str {
+        self.special_token_map
+            .pad_token
+            .as_deref()
+            .unwrap_or(DEFAULT_PAD_TOKEN)
     }
 
-    /// Returns the EOD token for XLNet (`<eod>`)
-    pub fn eod_value() -> &'static str {
-        "<eod>"
+    pub fn get_bos_value(&self) -> &str {
+        self.special_token_map
+            .bos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_BOS_TOKEN)
+    }
+
+    pub fn get_sep_value(&self) -> &str {
+        self.special_token_map
+            .sep_token
+            .as_deref()
+            .unwrap_or(DEFAULT_SEP_TOKEN)
+    }
+
+    pub fn get_cls_value(&self) -> &str {
+        self.special_token_map
+            .cls_token
+            .as_deref()
+            .unwrap_or(DEFAULT_CLS_TOKEN)
+    }
+
+    pub fn get_eos_value(&self) -> &str {
+        self.special_token_map
+            .eos_token
+            .as_deref()
+            .unwrap_or(DEFAULT_EOS_TOKEN)
+    }
+
+    pub fn get_mask_value(&self) -> &str {
+        self.special_token_map
+            .mask_token
+            .as_deref()
+            .unwrap_or(DEFAULT_MASK_TOKEN)
     }
 }
 
@@ -87,16 +129,16 @@ impl Vocab for XLNetVocab {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
-            unk_token: "<unk>".to_string(),
-            pad_token: Some("<pad>".to_string()),
-            bos_token: Some("<s>".to_string()),
-            sep_token: Some("<sep>".to_string()),
-            cls_token: Some("<cls>".to_string()),
-            eos_token: Some("</s>".to_string()),
-            mask_token: Some("<mask>".to_string()),
+            unk_token: DEFAULT_UNK_TOKEN.to_string(),
+            pad_token: Some(DEFAULT_PAD_TOKEN.to_string()),
+            bos_token: Some(DEFAULT_BOS_TOKEN.to_string()),
+            sep_token: Some(DEFAULT_SEP_TOKEN.to_string()),
+            cls_token: Some(DEFAULT_CLS_TOKEN.to_string()),
+            eos_token: Some(DEFAULT_EOS_TOKEN.to_string()),
+            mask_token: Some(DEFAULT_MASK_TOKEN.to_string()),
             additional_special_tokens: Some(HashSet::from([
-                "<eop>".to_string(),
-                "<eod>".to_string(),
+                DEFAULT_EOP_TOKEN.to_string(),
+                DEFAULT_EOD_TOKEN.to_string(),
             ])),
         };
         Self::from_values_and_special_token_map(values, special_token_map)

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -158,7 +158,7 @@ impl Vocab for XLNetVocab {
         special_token_map: SpecialTokenMap,
     ) -> Result<Self, TokenizerError>
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         let mut special_values = HashMap::new();
         special_token_map.register_special_values(&values, &mut special_values)?;

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -14,12 +14,8 @@ use crate::error::TokenizerError;
 use crate::vocab::base_vocab::{
     read_protobuf_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap,
 };
-use crate::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
 use crate::vocab::Vocab;
-use protobuf::Message;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::Read;
 
 /// # XLNet Vocab
 /// Vocabulary for XLNet tokenizer. Contains the following special values:
@@ -115,16 +111,42 @@ impl Vocab for XLNetVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
+    fn from_values_and_special_token_map(
+        values: HashMap<String, i64>,
+        special_token_map: SpecialTokenMap,
+    ) -> Result<Self, TokenizerError>
+    where
+        Self: std::marker::Sized,
+    {
+        let mut special_values = HashMap::new();
+        special_token_map.register_special_values(&values, &mut special_values)?;
+
+        let indices = swap_key_values(&values);
+        let special_indices = swap_key_values(&special_values);
+        Ok(Self {
+            values,
+            indices,
+            special_token_map,
+            special_values,
+            special_indices,
+        })
+    }
+
     fn token_to_id(&self, token: &str) -> i64 {
         self._token_to_id(
             token,
             &self.values,
             &self.special_values,
-            self.unknown_value,
+            self.get_unknown_value(),
         )
     }
 
     fn id_to_token(&self, id: &i64) -> String {
-        self._id_to_token(id, &self.indices, &self.special_indices, self.unknown_value)
+        self._id_to_token(
+            id,
+            &self.indices,
+            &self.special_indices,
+            self.get_unknown_value(),
+        )
     }
 }


### PR DESCRIPTION
This PR handles the addition of special token maps for all vocabularies and tokenizers.
- Normalizes the crate interface to special tokens 
- Replaces the `unknown_token` field of vocabs by `special_token_map` (this common token can still be accessed directly via `get_unknown_token()`)
- No longer hardcodes vocabs special tokens to static strings
- Refactors some duplicated code to read files

Todo: 
- [x] Update vocabs
- [x] Update tokenizers
- [x] Add special token map constructors to tokenizers
- [x] Fix unit tests
- [ ] Fix integration tests
