### PR TITLE
Use AsRef<Path> instead of &str.

### DIFF
--- a/main/Cargo.lock
+++ b/main/Cargo.lock
@@ -958,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -22,7 +22,7 @@ regex = "1.6.0"
 protobuf = "2.27.1"
 hashbrown = "0.12.3"
 unicode-normalization-alignments = "0.1.12"
-thiserror = "1.0.35"
+thiserror = "1.0.37"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/main/src/lib.rs
+++ b/main/src/lib.rs
@@ -43,8 +43,7 @@
 //! use rust_tokenizers::adapters::Example;
 //! use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer, TruncationStrategy};
 //! use rust_tokenizers::vocab::{BertVocab, Vocab};
-//!
-//! let vocab_path = std::path::Path::new("path/to/vocab");
+//! let vocab_path = "path/to/vocab";
 //! let vocab = BertVocab::from_file(&vocab_path)?;
 //!
 //! let test_sentence = Example::new_from_string("This is a sample sentence to be tokenized");

--- a/main/src/lib.rs
+++ b/main/src/lib.rs
@@ -43,7 +43,8 @@
 //! use rust_tokenizers::adapters::Example;
 //! use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer, TruncationStrategy};
 //! use rust_tokenizers::vocab::{BertVocab, Vocab};
-//! let vocab_path = "path/to/vocab";
+//!
+//! let vocab_path = std::path::Path::new("path/to/vocab");
 //! let vocab = BertVocab::from_file(&vocab_path)?;
 //!
 //! let test_sentence = Example::new_from_string("This is a sample sentence to be tokenized");

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -53,10 +53,12 @@ impl AlbertTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     AlbertTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     AlbertTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -86,13 +88,15 @@ impl AlbertTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = AlbertTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -126,10 +130,12 @@ impl AlbertTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{AlbertVocab, SentencePieceModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let vocab = AlbertVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = AlbertVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer =
     ///     AlbertTokenizer::from_existing_vocab_and_model(vocab, model, lower_case, strip_accents);

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -53,12 +53,10 @@ impl AlbertTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     AlbertTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     AlbertTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -88,15 +86,13 @@ impl AlbertTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = AlbertTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -130,12 +126,10 @@ impl AlbertTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{AlbertTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{AlbertVocab, SentencePieceModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let vocab = AlbertVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = AlbertVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer =
     ///     AlbertTokenizer::from_existing_vocab_and_model(vocab, model, lower_case, strip_accents);

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::tokenization_utils::{
     clean_text, decompose_nfkc, is_whitespace, lowercase, replace_string, split_on_special_tokens,
@@ -57,7 +59,7 @@ impl AlbertTokenizer {
     ///     AlbertTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<AlbertTokenizer, TokenizerError> {
@@ -95,10 +97,10 @@ impl AlbertTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<AlbertTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab =

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -60,12 +60,12 @@ impl AlbertTokenizer {
     /// let tokenizer =
     ///     AlbertTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<AlbertTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = AlbertVocab::from_file(path)?;
         Ok(AlbertTokenizer {
             model,
@@ -100,13 +100,13 @@ impl AlbertTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<T: AsRef<Path>, S: AsRef<Path>>(
+        path: T,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<AlbertTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab =
             AlbertVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(AlbertTokenizer {

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -484,12 +484,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text = "Hello, world!";
     /// let tokens = tokenizer.tokenize(text);
@@ -511,12 +509,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text = "Hello, world!";
     /// let tokens = tokenizer.tokenize_with_offsets(text);
@@ -576,12 +572,10 @@ pub trait Tokenizer<T: Vocab> {
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
     /// use rust_tokenizers::{OffsetSize, TokenRef};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text = "Hello, world!";
     /// let offsets = (0..text.len() as OffsetSize).collect_vec();
@@ -603,12 +597,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let texts = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list(&texts);
@@ -639,12 +631,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list_with_offsets(&text);
@@ -673,12 +663,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let tokens = ["Hello", ",", "world", "!"];
     /// let token_ids = tokenizer.convert_tokens_to_ids(&tokens);
@@ -715,12 +703,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "How is it going?";
@@ -841,12 +827,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "How is it going?";
@@ -896,12 +880,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "This is a second sentence";
@@ -953,12 +935,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let tokens_ids = vec![0, 1, 2, 42];
     /// let tokens = tokenizer.decode_to_vec(&tokens_ids, false);
@@ -995,12 +975,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1036,12 +1014,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1070,12 +1046,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1114,12 +1088,10 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1164,12 +1136,10 @@ pub trait Tokenizer<T: Vocab> {
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
     /// use rust_tokenizers::TokenIdsWithOffsets;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1258,12 +1228,10 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list_with_offsets(&text);
@@ -1292,12 +1260,10 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let texts = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list(&texts);
@@ -1334,12 +1300,10 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "How is it going?";
@@ -1389,12 +1353,10 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "This is a second sentence";
@@ -1449,12 +1411,10 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1511,15 +1471,13 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer: BaseTokenizer<BaseVocab> = BaseTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -1550,12 +1508,10 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -1582,11 +1538,9 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BaseVocab, Vocab};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let base_vocab = BaseVocab::from_file(&path).unwrap();
+    /// let base_vocab = BaseVocab::from_file("path/to/vocab/file").unwrap();
     ///
     /// let tokenizer = BaseTokenizer::from_existing_vocab(base_vocab, lower_case, strip_accents);
     /// ```

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::tokenization_utils::{clean_text, lowercase};
 use crate::tokenizer::tokenization_utils::{
@@ -1480,10 +1482,10 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<BaseTokenizer<T>, TokenizerError> {
         let vocab = T::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(BaseTokenizer {
@@ -1512,7 +1514,7 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<BaseTokenizer<T>, TokenizerError> {

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -484,10 +484,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text = "Hello, world!";
     /// let tokens = tokenizer.tokenize(text);
@@ -509,10 +511,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text = "Hello, world!";
     /// let tokens = tokenizer.tokenize_with_offsets(text);
@@ -572,10 +576,12 @@ pub trait Tokenizer<T: Vocab> {
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
     /// use rust_tokenizers::{OffsetSize, TokenRef};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text = "Hello, world!";
     /// let offsets = (0..text.len() as OffsetSize).collect_vec();
@@ -597,10 +603,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let texts = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list(&texts);
@@ -631,10 +639,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list_with_offsets(&text);
@@ -663,10 +673,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let tokens = ["Hello", ",", "world", "!"];
     /// let token_ids = tokenizer.convert_tokens_to_ids(&tokens);
@@ -703,10 +715,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "How is it going?";
@@ -827,10 +841,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "How is it going?";
@@ -880,10 +896,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "This is a second sentence";
@@ -935,10 +953,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let tokens_ids = vec![0, 1, 2, 42];
     /// let tokens = tokenizer.decode_to_vec(&tokens_ids, false);
@@ -975,10 +995,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1014,10 +1036,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1046,10 +1070,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1088,10 +1114,12 @@ pub trait Tokenizer<T: Vocab> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1136,10 +1164,12 @@ pub trait Tokenizer<T: Vocab> {
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
     /// use rust_tokenizers::TokenIdsWithOffsets;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1228,10 +1258,12 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list_with_offsets(&text);
@@ -1260,10 +1292,12 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let texts = ["Hello, world!", "Second sentence"];
     /// let tokens = tokenizer.tokenize_list(&texts);
@@ -1300,10 +1334,12 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "How is it going?";
@@ -1353,10 +1389,12 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let text_1 = "Hello, world!";
     /// let text_2 = "This is a second sentence";
@@ -1411,10 +1449,12 @@ where
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, MultiThreadedTokenizer, TruncationStrategy};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     ///
     /// let skip_special_tokens = true;
     /// let clean_up_tokenization_spaces = true;
@@ -1471,13 +1511,15 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer: BaseTokenizer<BaseVocab> = BaseTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -1508,10 +1550,12 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::BaseVocab;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer: BaseTokenizer<BaseVocab> =
-    ///     BaseTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -1538,9 +1582,11 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BaseTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BaseVocab, Vocab};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let base_vocab = BaseVocab::from_file("path/to/vocab/file").unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let base_vocab = BaseVocab::from_file(&path).unwrap();
     ///
     /// let tokenizer = BaseTokenizer::from_existing_vocab(base_vocab, lower_case, strip_accents);
     /// ```

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -1523,11 +1523,11 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<BaseTokenizer<T>, TokenizerError> {
         let vocab = T::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(BaseTokenizer {
@@ -1557,8 +1557,8 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
     /// let tokenizer: BaseTokenizer<BaseVocab> =
     ///     BaseTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<BaseTokenizer<T>, TokenizerError> {

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     BaseTokenizer, Mask, MultiThreadedTokenizer, Offset, OffsetSize, Token, TokenIdsWithOffsets,
@@ -48,7 +50,7 @@ impl BertTokenizer {
     ///     BertTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<BertTokenizer, TokenizerError> {
@@ -85,10 +87,10 @@ impl BertTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<BertTokenizer, TokenizerError> {
         let vocab =
             BertVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -46,8 +46,9 @@ impl BertTokenizer {
     /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     BertTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     BertTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -76,13 +77,15 @@ impl BertTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = BertTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -113,9 +116,11 @@ impl BertTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let vocab = BertVocab::from_file("path/to/vocab/file").unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let vocab = BertVocab::from_file(&path).unwrap();
     ///
     /// let tokenizer = BertTokenizer::from_existing_vocab(vocab, lower_case, strip_accents);
     /// ```

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -50,8 +50,8 @@ impl BertTokenizer {
     /// let tokenizer =
     ///     BertTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<BertTokenizer, TokenizerError> {
@@ -89,11 +89,11 @@ impl BertTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<BertTokenizer, TokenizerError> {
         let vocab =
             BertVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -46,9 +46,8 @@ impl BertTokenizer {
     /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     BertTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     BertTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -77,15 +76,13 @@ impl BertTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = BertTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -116,11 +113,9 @@ impl BertTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{BertTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let vocab = BertVocab::from_file(&path).unwrap();
+    /// let vocab = BertVocab::from_file("path/to/vocab/file").unwrap();
     ///
     /// let tokenizer = BertTokenizer::from_existing_vocab(vocab, lower_case, strip_accents);
     /// ```

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -53,9 +53,11 @@ impl CtrlTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     CtrlTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case).unwrap();
+    ///     CtrlTokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case).unwrap();
     /// ```
     pub fn from_file(
         vocab_path: &Path,
@@ -88,12 +90,14 @@ impl CtrlTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = CtrlTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/merges/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/merges/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -131,9 +135,11 @@ impl CtrlTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, OpenAiGptVocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = OpenAiGptVocab::from_file("path/to/vocab/file").unwrap();
-    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
+    /// let vocab = OpenAiGptVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
     ///
     /// let tokenizer = CtrlTokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -53,11 +53,9 @@ impl CtrlTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     CtrlTokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case).unwrap();
+    ///     CtrlTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case).unwrap();
     /// ```
     pub fn from_file<V: AsRef<Path>, M: AsRef<Path>>(
         vocab_path: V,
@@ -90,14 +88,12 @@ impl CtrlTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = CtrlTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/merges/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -135,11 +131,9 @@ impl CtrlTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{CtrlTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, OpenAiGptVocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = OpenAiGptVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
+    /// let vocab = OpenAiGptVocab::from_file("path/to/vocab/file").unwrap();
+    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
     ///
     /// let tokenizer = CtrlTokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -23,6 +23,7 @@ use crate::vocab::{OpenAiGptVocab, Vocab};
 use crate::{Mask, Token, TokenRef};
 use regex::Regex;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::RwLock;
 
 /// # CTRL tokenizer
@@ -57,8 +58,8 @@ impl CtrlTokenizer {
     ///     CtrlTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case).unwrap();
     /// ```
     pub fn from_file(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
     ) -> Result<CtrlTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file(vocab_path)?;
@@ -97,10 +98,10 @@ impl CtrlTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<CtrlTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -59,9 +59,9 @@ impl CtrlTokenizer {
     /// let tokenizer =
     ///     CtrlTokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file<V: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: V,
+        merges_path: M,
         lower_case: bool,
     ) -> Result<CtrlTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file(vocab_path)?;
@@ -101,11 +101,11 @@ impl CtrlTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        merges_path: M,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<CtrlTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -58,11 +58,9 @@ impl DeBERTaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     DeBERTaTokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case)
+    ///     DeBERTaTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case)
     ///         .unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
@@ -99,22 +97,20 @@ impl DeBERTaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = DeBERTaTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/merges/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        merges_path: M,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<DeBERTaTokenizer, TokenizerError> {
         let vocab = DeBERTaVocab::from_file_with_special_token_mapping(
             vocab_path,
@@ -148,11 +144,9 @@ impl DeBERTaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, DeBERTaVocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = DeBERTaVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
+    /// let vocab = DeBERTaVocab::from_file("path/to/vocab/file").unwrap();
+    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
     ///
     /// let tokenizer = DeBERTaTokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -27,6 +27,7 @@ use itertools::Itertools;
 use regex::Regex;
 use std::collections::HashMap;
 use std::iter::Iterator;
+use std::path::Path;
 use std::sync::RwLock;
 
 /// # DeBERTa tokenizer
@@ -63,10 +64,10 @@ impl DeBERTaTokenizer {
     ///         .unwrap();
     /// ```
     pub fn from_file(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
-    ) -> Result<DeBERTaTokenizer, TokenizerError> {
+    ) -> Result<Self, TokenizerError> {
         let vocab = DeBERTaVocab::from_file(vocab_path)?;
         let bpe_ranks = BpePairVocab::from_file(merges_path)?;
         let cache = RwLock::new(HashMap::new());
@@ -74,7 +75,7 @@ impl DeBERTaTokenizer {
         let pattern_tokenization =
             Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+")
                 .unwrap();
-        Ok(DeBERTaTokenizer {
+        Ok(Self {
             vocab,
             bpe_ranks,
             cache,
@@ -106,10 +107,10 @@ impl DeBERTaTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<DeBERTaTokenizer, TokenizerError> {
         let vocab = DeBERTaVocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -58,9 +58,11 @@ impl DeBERTaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     DeBERTaTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case)
+    ///     DeBERTaTokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case)
     ///         .unwrap();
     /// ```
     pub fn from_file(
@@ -97,12 +99,14 @@ impl DeBERTaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = DeBERTaTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/merges/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/merges/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -144,9 +148,11 @@ impl DeBERTaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, DeBERTaVocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = DeBERTaVocab::from_file("path/to/vocab/file").unwrap();
-    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
+    /// let vocab = DeBERTaVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
     ///
     /// let tokenizer = DeBERTaTokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -65,9 +65,9 @@ impl DeBERTaTokenizer {
     ///     DeBERTaTokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case)
     ///         .unwrap();
     /// ```
-    pub fn from_file(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: P,
+        merges_path: M,
         lower_case: bool,
     ) -> Result<Self, TokenizerError> {
         let vocab = DeBERTaVocab::from_file(vocab_path)?;

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -66,8 +66,8 @@ impl DeBERTaV2Tokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
         add_prefix_space: bool,

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -53,13 +53,11 @@ impl DeBERTaV2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaV2Tokenizer, Tokenizer};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let add_prefix_space = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = DeBERTaV2Tokenizer::from_file(
-    ///     &path,
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
     ///     add_prefix_space,
@@ -96,28 +94,26 @@ impl DeBERTaV2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaV2Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let add_prefix_space = false;
     /// let tokenizer = DeBERTaV2Tokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
     ///     add_prefix_space,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
         add_prefix_space: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<DeBERTaV2Tokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab =
             DeBERTaV2Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(DeBERTaV2Tokenizer {
@@ -143,13 +139,11 @@ impl DeBERTaV2Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::DeBERTaV2Tokenizer;
     /// use rust_tokenizers::vocab::{DeBERTaV2Vocab, SentencePieceModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let add_prefix_space = false;
-    /// let vocab = DeBERTaV2Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = DeBERTaV2Vocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = DeBERTaV2Tokenizer::from_existing_vocab_and_model(
     ///     vocab,

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -22,6 +22,7 @@ use crate::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
 };
 use std::iter::Iterator;
+use std::path::Path;
 
 /// # DeBERTaV2 tokenizer
 /// DeBERTa (v2) tokenizer (based on SentencePiece) performing:
@@ -64,12 +65,12 @@ impl DeBERTaV2Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
         add_prefix_space: bool,
     ) -> Result<DeBERTaV2Tokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = DeBERTaV2Vocab::from_file(path)?;
         Ok(DeBERTaV2Tokenizer {
             model,
@@ -106,11 +107,11 @@ impl DeBERTaV2Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
         add_prefix_space: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<DeBERTaV2Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab =

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -53,11 +53,13 @@ impl DeBERTaV2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaV2Tokenizer, Tokenizer};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let add_prefix_space = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = DeBERTaV2Tokenizer::from_file(
-    ///     "path/to/vocab/file",
+    ///     &path,
     ///     lower_case,
     ///     strip_accents,
     ///     add_prefix_space,
@@ -94,15 +96,17 @@ impl DeBERTaV2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{DeBERTaV2Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let add_prefix_space = false;
     /// let tokenizer = DeBERTaV2Tokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
     ///     add_prefix_space,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -139,11 +143,13 @@ impl DeBERTaV2Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::DeBERTaV2Tokenizer;
     /// use rust_tokenizers::vocab::{DeBERTaV2Vocab, SentencePieceModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let add_prefix_space = false;
-    /// let vocab = DeBERTaV2Vocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = DeBERTaV2Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = DeBERTaV2Tokenizer::from_existing_vocab_and_model(
     ///     vocab,

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::tokenization_utils::{
     clean_text, decompose_nfkc, is_whitespace, lowercase, replace_string, split_on_special_tokens,
@@ -57,7 +59,7 @@ impl FNetTokenizer {
     ///     FNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<FNetTokenizer, TokenizerError> {
@@ -95,10 +97,10 @@ impl FNetTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<FNetTokenizer, TokenizerError> {
         let model = SentencePieceBpeModel::from_file(path)?;
         let vocab =

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -53,10 +53,12 @@ impl FNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{FNetTokenizer, Tokenizer};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     FNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     FNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -86,13 +88,15 @@ impl FNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{FNetTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = FNetTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -126,10 +130,12 @@ impl FNetTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::FNetTokenizer;
     /// use rust_tokenizers::vocab::{FNetVocab, SentencePieceBpeModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let vocab = FNetVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceBpeModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = FNetVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceBpeModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer =
     ///     FNetTokenizer::from_existing_vocab_and_model(vocab, model, lower_case, strip_accents);

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -53,12 +53,10 @@ impl FNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{FNetTokenizer, Tokenizer};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     FNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     FNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -88,15 +86,13 @@ impl FNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{FNetTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = FNetTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -130,12 +126,10 @@ impl FNetTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::FNetTokenizer;
     /// use rust_tokenizers::vocab::{FNetVocab, SentencePieceBpeModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let vocab = FNetVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceBpeModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = FNetVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceBpeModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer =
     ///     FNetTokenizer::from_existing_vocab_and_model(vocab, model, lower_case, strip_accents);

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -60,12 +60,12 @@ impl FNetTokenizer {
     /// let tokenizer =
     ///     FNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<FNetTokenizer, TokenizerError> {
-        let model = SentencePieceBpeModel::from_file(path)?;
+        let model = SentencePieceBpeModel::from_file(&path)?;
         let vocab = FNetVocab::from_file(path)?;
         Ok(FNetTokenizer {
             model,
@@ -100,13 +100,13 @@ impl FNetTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<FNetTokenizer, TokenizerError> {
-        let model = SentencePieceBpeModel::from_file(path)?;
+        let model = SentencePieceBpeModel::from_file(&path)?;
         let vocab =
             FNetVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(FNetTokenizer {

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -63,9 +63,9 @@ impl Gpt2Tokenizer {
     /// let tokenizer =
     ///     Gpt2Tokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: P,
+        merges_path: M,
         lower_case: bool,
     ) -> Result<Gpt2Tokenizer, TokenizerError> {
         let vocab = Gpt2Vocab::from_file(vocab_path)?;

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -57,9 +57,11 @@ impl Gpt2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     Gpt2Tokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case).unwrap();
+    ///     Gpt2Tokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case).unwrap();
     /// ```
     pub fn from_file(
         vocab_path: &Path,
@@ -96,12 +98,14 @@ impl Gpt2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = Gpt2Tokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/merges/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/merges/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -143,9 +147,11 @@ impl Gpt2Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, Gpt2Vocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = Gpt2Vocab::from_file("path/to/vocab/file").unwrap();
-    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
+    /// let vocab = Gpt2Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
     ///
     /// let tokenizer = Gpt2Tokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -57,11 +57,9 @@ impl Gpt2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     Gpt2Tokenizer::from_file(&Path::new("path/to/vocab/file"), &Path::new("path/to/merges/file"), lower_case).unwrap();
+    ///     Gpt2Tokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
         vocab_path: P,
@@ -98,22 +96,20 @@ impl Gpt2Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = Gpt2Tokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/merges/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        merges_path: M,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<Gpt2Tokenizer, TokenizerError> {
         let vocab = Gpt2Vocab::from_file_with_special_token_mapping(
             vocab_path,
@@ -147,11 +143,9 @@ impl Gpt2Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Gpt2Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, Gpt2Vocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = Gpt2Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
+    /// let vocab = Gpt2Vocab::from_file("path/to/vocab/file").unwrap();
+    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
     ///
     /// let tokenizer = Gpt2Tokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -26,6 +26,7 @@ use itertools::Itertools;
 use regex::Regex;
 use std::collections::HashMap;
 use std::iter::Iterator;
+use std::path::Path;
 use std::sync::RwLock;
 
 /// # GPT2 tokenizer
@@ -61,8 +62,8 @@ impl Gpt2Tokenizer {
     ///     Gpt2Tokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case).unwrap();
     /// ```
     pub fn from_file(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
     ) -> Result<Gpt2Tokenizer, TokenizerError> {
         let vocab = Gpt2Vocab::from_file(vocab_path)?;
@@ -105,10 +106,10 @@ impl Gpt2Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<Gpt2Tokenizer, TokenizerError> {
         let vocab = Gpt2Vocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
@@ -56,8 +58,8 @@ impl M2M100Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_files(
-        vocab_path: &str,
-        model_path: &str,
+        vocab_path: &Path,
+        model_path: &Path,
         lower_case: bool,
     ) -> Result<M2M100Tokenizer, TokenizerError> {
         let vocab = M2M100Vocab::from_file(vocab_path)?;
@@ -93,10 +95,10 @@ impl M2M100Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_files_with_special_token_mapping(
-        vocab_path: &str,
-        model_path: &str,
+        vocab_path: &Path,
+        model_path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<M2M100Tokenizer, TokenizerError> {
         let vocab = M2M100Vocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -59,9 +59,9 @@ impl M2M100Tokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_files(
-        vocab_path: &Path,
-        model_path: &Path,
+    pub fn from_files<V: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: V,
+        model_path: M,
         lower_case: bool,
     ) -> Result<M2M100Tokenizer, TokenizerError> {
         let vocab = M2M100Vocab::from_file(vocab_path)?;

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -49,12 +49,10 @@ impl M2M100Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = M2M100Tokenizer::from_files(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/spiece/model/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/spiece/model/file",
     ///     lower_case,
     /// )
     /// .unwrap();
@@ -87,22 +85,20 @@ impl M2M100Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = M2M100Tokenizer::from_files_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/spiece/model/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/spiece/model/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_files_with_special_token_mapping(
-        vocab_path: &Path,
-        model_path: &Path,
+    pub fn from_files_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        model_path: M,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<M2M100Tokenizer, TokenizerError> {
         let vocab = M2M100Vocab::from_file_with_special_token_mapping(
             vocab_path,
@@ -129,11 +125,9 @@ impl M2M100Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{M2M100Vocab, SentencePieceBpeModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = M2M100Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceBpeModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = M2M100Vocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceBpeModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = M2M100Tokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -49,10 +49,12 @@ impl M2M100Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = M2M100Tokenizer::from_files(
-    ///     "path/to/vocab/file",
-    ///     "path/to/spiece/model/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/spiece/model/file"),
     ///     lower_case,
     /// )
     /// .unwrap();
@@ -85,12 +87,14 @@ impl M2M100Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = M2M100Tokenizer::from_files_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/spiece/model/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/spiece/model/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -125,9 +129,11 @@ impl M2M100Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{M2M100Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{M2M100Vocab, SentencePieceBpeModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = M2M100Vocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceBpeModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = M2M100Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceBpeModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = M2M100Tokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
@@ -55,8 +57,8 @@ impl MarianTokenizer {
     ///         .unwrap();
     /// ```
     pub fn from_files(
-        vocab_path: &str,
-        model_path: &str,
+        vocab_path: &Path,
+        model_path: &Path,
         lower_case: bool,
     ) -> Result<MarianTokenizer, TokenizerError> {
         let vocab = MarianVocab::from_file(vocab_path)?;
@@ -93,10 +95,10 @@ impl MarianTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_files_with_special_token_mapping(
-        vocab_path: &str,
-        model_path: &str,
+        vocab_path: &Path,
+        model_path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<MarianTokenizer, TokenizerError> {
         let vocab = MarianVocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -61,9 +61,9 @@ impl MarianTokenizer {
     ///         lower_case)
     ///     .unwrap();
     /// ```
-    pub fn from_files(
-        vocab_path: &Path,
-        model_path: &Path,
+    pub fn from_files<V: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: V,
+        model_path: M,
         lower_case: bool,
     ) -> Result<MarianTokenizer, TokenizerError> {
         let vocab = MarianVocab::from_file(vocab_path)?;

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -51,15 +51,10 @@ impl MarianTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     MarianTokenizer::from_files(
-    ///         &Path::new("path/to/vocab/file"),
-    ///         &Path::new("path/to/model/file"),
-    ///         lower_case)
-    ///     .unwrap();
+    ///     MarianTokenizer::from_files("path/to/vocab/file", "path/to/model/file", lower_case)
+    ///         .unwrap();
     /// ```
     pub fn from_files<V: AsRef<Path>, M: AsRef<Path>>(
         vocab_path: V,
@@ -90,22 +85,20 @@ impl MarianTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = MarianTokenizer::from_files_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/model/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/model/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_files_with_special_token_mapping(
-        vocab_path: &Path,
-        model_path: &Path,
+    pub fn from_files_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        model_path: M,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<MarianTokenizer, TokenizerError> {
         let vocab = MarianVocab::from_file_with_special_token_mapping(
             vocab_path,
@@ -133,11 +126,9 @@ impl MarianTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{MarianVocab, SentencePieceModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = MarianVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = MarianVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = MarianTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -51,10 +51,15 @@ impl MarianTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     MarianTokenizer::from_files("path/to/vocab/file", "path/to/model/file", lower_case)
-    ///         .unwrap();
+    ///     MarianTokenizer::from_files(
+    ///         &Path::new("path/to/vocab/file"),
+    ///         &Path::new("path/to/model/file"),
+    ///         lower_case)
+    ///     .unwrap();
     /// ```
     pub fn from_files(
         vocab_path: &Path,
@@ -85,12 +90,14 @@ impl MarianTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = MarianTokenizer::from_files_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/model/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/model/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -126,9 +133,11 @@ impl MarianTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MarianTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{MarianVocab, SentencePieceModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = MarianVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = MarianVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = MarianTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -53,7 +53,7 @@ impl MBart50Tokenizer {
     /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = MBart50Tokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &Path, lower_case: bool) -> Result<MBart50Tokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<MBart50Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = MBart50Vocab::from_file(path)?;
         Ok(MBart50Tokenizer {
@@ -85,12 +85,12 @@ impl MBart50Tokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<MBart50Tokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab =
             MBart50Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(MBart50Tokenizer {

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -48,13 +48,12 @@ impl MBart50Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
+    ///
     /// let lower_case = false;
-    /// let tokenizer = MBart50Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let tokenizer = MBart50Tokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
-        lower_case: bool,
-    ) -> Result<MBart50Tokenizer, TokenizerError> {
+    pub fn from_file(path: &Path, lower_case: bool) -> Result<MBart50Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = MBart50Vocab::from_file(path)?;
         Ok(MBart50Tokenizer {
@@ -76,11 +75,13 @@ impl MBart50Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = MBart50Tokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -111,9 +112,11 @@ impl MBart50Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{MBart50Vocab, SentencePieceModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = MBart50Vocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = MBart50Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = MBart50Tokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -48,10 +48,8 @@ impl MBart50Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
-    ///
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let tokenizer = MBart50Tokenizer::from_file(&path, lower_case).unwrap();
+    /// let tokenizer = MBart50Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<MBart50Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
@@ -75,13 +73,11 @@ impl MBart50Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = MBart50Tokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -112,11 +108,9 @@ impl MBart50Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{MBart50Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{MBart50Vocab, SentencePieceModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = MBart50Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = MBart50Vocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = MBart50Tokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -51,7 +51,10 @@ impl MBart50Tokenizer {
     /// let lower_case = false;
     /// let tokenizer = MBart50Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<MBart50Tokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
+        lower_case: bool,
+    ) -> Result<MBart50Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = MBart50Vocab::from_file(path)?;
         Ok(MBart50Tokenizer {

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
@@ -49,8 +51,11 @@ impl MBart50Tokenizer {
     /// let lower_case = false;
     /// let tokenizer = MBart50Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &str, lower_case: bool) -> Result<MBart50Tokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+    pub fn from_file(
+        path: &Path,
+        lower_case: bool,
+    ) -> Result<MBart50Tokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = MBart50Vocab::from_file(path)?;
         Ok(MBart50Tokenizer {
             model,
@@ -80,9 +85,9 @@ impl MBart50Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<MBart50Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab =

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -46,10 +46,15 @@ impl OpenAiGptTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     OpenAiGptTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case)
-    ///         .unwrap();
+    ///     OpenAiGptTokenizer::from_file(
+    ///         &Path::new("path/to/vocab/file"),
+    ///         &Path::new("path/to/merges/file"),
+    ///         lower_case)
+    ///     .unwrap();
     /// ```
     pub fn from_file(
         vocab_path: &Path,
@@ -81,12 +86,14 @@ impl OpenAiGptTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = OpenAiGptTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/merges/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/merges/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -123,9 +130,11 @@ impl OpenAiGptTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, OpenAiGptVocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = OpenAiGptVocab::from_file("path/to/vocab/file").unwrap();
-    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
+    /// let vocab = OpenAiGptVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
     ///
     /// let tokenizer = OpenAiGptTokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -46,15 +46,10 @@ impl OpenAiGptTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer =
-    ///     OpenAiGptTokenizer::from_file(
-    ///         &Path::new("path/to/vocab/file"),
-    ///         &Path::new("path/to/merges/file"),
-    ///         lower_case)
-    ///     .unwrap();
+    ///     OpenAiGptTokenizer::from_file("path/to/vocab/file", "path/to/merges/file", lower_case)
+    ///         .unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
         vocab_path: P,
@@ -86,22 +81,20 @@ impl OpenAiGptTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = OpenAiGptTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/merges/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        merges_path: M,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<OpenAiGptTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file_with_special_token_mapping(
             vocab_path,
@@ -130,11 +123,9 @@ impl OpenAiGptTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{OpenAiGptTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, OpenAiGptVocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = OpenAiGptVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
+    /// let vocab = OpenAiGptVocab::from_file("path/to/vocab/file").unwrap();
+    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
     ///
     /// let tokenizer = OpenAiGptTokenizer::from_existing_vocab_and_merges(vocab, merges, lower_case);
     /// ```

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -19,6 +19,7 @@ use crate::vocab::bpe_vocab::BpePairVocab;
 use crate::vocab::{OpenAiGptVocab, Vocab};
 use crate::{Mask, Token, TokenRef};
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::RwLock;
 
 /// # GPT tokenizer
@@ -51,8 +52,8 @@ impl OpenAiGptTokenizer {
     ///         .unwrap();
     /// ```
     pub fn from_file(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
     ) -> Result<OpenAiGptTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file(vocab_path)?;
@@ -90,10 +91,10 @@ impl OpenAiGptTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<OpenAiGptTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -56,9 +56,9 @@ impl OpenAiGptTokenizer {
     ///         lower_case)
     ///     .unwrap();
     /// ```
-    pub fn from_file(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: P,
+        merges_path: M,
         lower_case: bool,
     ) -> Result<OpenAiGptTokenizer, TokenizerError> {
         let vocab = OpenAiGptVocab::from_file(vocab_path)?;

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -46,8 +46,7 @@ impl PegasusTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let tokenizer = PegasusTokenizer::from_file(&path, lower_case).unwrap();
+    /// let tokenizer = PegasusTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab = PegasusVocab::from_file(&path)?;
@@ -71,13 +70,11 @@ impl PegasusTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = PegasusTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -108,11 +105,9 @@ impl PegasusTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{PegasusVocab, SentencePieceModel, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = PegasusVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = PegasusVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = PegasusTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -49,7 +49,7 @@ impl PegasusTokenizer {
     /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = PegasusTokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &Path, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab = PegasusVocab::from_file(&path)?;
         let model = SentencePieceModel::from_file(path)?;
         Ok(PegasusTokenizer {
@@ -81,13 +81,13 @@ impl PegasusTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab =
-            PegasusVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+            PegasusVocab::from_file_with_special_token_mapping(&path, special_token_mapping_path)?;
         let model = SentencePieceModel::from_file(path)?;
         Ok(PegasusTokenizer {
             model,

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -48,7 +48,10 @@ impl PegasusTokenizer {
     /// let lower_case = false;
     /// let tokenizer = PegasusTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
+        lower_case: bool,
+    ) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab = PegasusVocab::from_file(&path)?;
         let model = SentencePieceModel::from_file(path)?;
         Ok(PegasusTokenizer {

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -46,12 +46,10 @@ impl PegasusTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
     /// let lower_case = false;
-    /// let tokenizer = PegasusTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let tokenizer = PegasusTokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
-        lower_case: bool,
-    ) -> Result<PegasusTokenizer, TokenizerError> {
+    pub fn from_file(path: &Path, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab = PegasusVocab::from_file(&path)?;
         let model = SentencePieceModel::from_file(path)?;
         Ok(PegasusTokenizer {
@@ -73,11 +71,13 @@ impl PegasusTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = PegasusTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -108,9 +108,11 @@ impl PegasusTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{PegasusTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{PegasusVocab, SentencePieceModel, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = PegasusVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = PegasusVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = PegasusTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
@@ -46,8 +48,11 @@ impl PegasusTokenizer {
     /// let lower_case = false;
     /// let tokenizer = PegasusTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &str, lower_case: bool) -> Result<PegasusTokenizer, TokenizerError> {
-        let vocab = PegasusVocab::from_file(path)?;
+    pub fn from_file(
+        path: &Path,
+        lower_case: bool,
+    ) -> Result<PegasusTokenizer, TokenizerError> {
+        let vocab = PegasusVocab::from_file(&path)?;
         let model = SentencePieceModel::from_file(path)?;
         Ok(PegasusTokenizer {
             model,
@@ -77,9 +82,9 @@ impl PegasusTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<PegasusTokenizer, TokenizerError> {
         let vocab =
             PegasusVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -43,10 +43,12 @@ impl ProphetNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{ProphetNetTokenizer, Tokenizer};
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     ProphetNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     ProphetNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -75,13 +77,15 @@ impl ProphetNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{ProphetNetTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = ProphetNetTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -117,7 +121,8 @@ impl ProphetNetTokenizer {
     /// use rust_tokenizers::vocab::{ProphetNetVocab, Vocab};
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let vocab = ProphetNetVocab::from_file("path/to/vocab/file").unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let vocab = ProphetNetVocab::from_file(&path).unwrap();
     ///
     /// let tokenizer = ProphetNetTokenizer::from_existing_vocab(vocab, lower_case, strip_accents);
     /// ```

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -50,8 +50,8 @@ impl ProphetNetTokenizer {
     /// let tokenizer =
     ///     ProphetNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<ProphetNetTokenizer, TokenizerError> {
@@ -89,11 +89,11 @@ impl ProphetNetTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<ProphetNetTokenizer, TokenizerError> {
         let vocab = ProphetNetVocab::from_file_with_special_token_mapping(
             path,

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -43,12 +43,10 @@ impl ProphetNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{ProphetNetTokenizer, Tokenizer};
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     ProphetNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     ProphetNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -77,15 +75,13 @@ impl ProphetNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{ProphetNetTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let strip_accents = false;
     /// let lower_case = false;
     /// let tokenizer = ProphetNetTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -121,8 +117,7 @@ impl ProphetNetTokenizer {
     /// use rust_tokenizers::vocab::{ProphetNetVocab, Vocab};
     /// let strip_accents = false;
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let vocab = ProphetNetVocab::from_file(&path).unwrap();
+    /// let vocab = ProphetNetVocab::from_file("path/to/vocab/file").unwrap();
     ///
     /// let tokenizer = ProphetNetTokenizer::from_existing_vocab(vocab, lower_case, strip_accents);
     /// ```

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     BaseTokenizer, Mask, MultiThreadedTokenizer, Offset, OffsetSize, Token, TokenIdsWithOffsets,
@@ -47,7 +49,7 @@ impl ProphetNetTokenizer {
     ///     ProphetNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<ProphetNetTokenizer, TokenizerError> {
@@ -84,10 +86,10 @@ impl ProphetNetTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<ProphetNetTokenizer, TokenizerError> {
         let vocab = ProphetNetVocab::from_file_with_special_token_mapping(
             path,

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -45,13 +45,12 @@ impl ReformerTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    ///
     /// let lower_case = false;
-    /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let tokenizer = SentencePieceTokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
-        lower_case: bool,
-    ) -> Result<ReformerTokenizer, TokenizerError> {
+    pub fn from_file(path: &Path, lower_case: bool) -> Result<ReformerTokenizer, TokenizerError> {
         let vocab = ReformerVocab::from_file(&path)?;
         let bpe_ranks = BpePairVocab::from_sentencepiece_file(path)?;
         let cache = RwLock::new(HashMap::new());
@@ -76,11 +75,13 @@ impl ReformerTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -50,7 +50,7 @@ impl ReformerTokenizer {
     /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = SentencePieceTokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &Path, lower_case: bool) -> Result<ReformerTokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<ReformerTokenizer, TokenizerError> {
         let vocab = ReformerVocab::from_file(&path)?;
         let bpe_ranks = BpePairVocab::from_sentencepiece_file(path)?;
         let cache = RwLock::new(HashMap::new());
@@ -85,13 +85,13 @@ impl ReformerTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<ReformerTokenizer, TokenizerError> {
         let vocab =
-            ReformerVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+            ReformerVocab::from_file_with_special_token_mapping(&path, special_token_mapping_path)?;
         let bpe_ranks = BpePairVocab::from_sentencepiece_file(path)?;
         let cache = RwLock::new(HashMap::new());
         Ok(ReformerTokenizer {

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -21,6 +21,7 @@ use crate::tokenizer::{MultiThreadedTokenizer, Tokenizer};
 use crate::vocab::{BpePairVocab, ReformerVocab, Vocab};
 use crate::Mask;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::RwLock;
 
 /// # Reformer tokenizer
@@ -47,8 +48,11 @@ impl ReformerTokenizer {
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &str, lower_case: bool) -> Result<ReformerTokenizer, TokenizerError> {
-        let vocab = ReformerVocab::from_file(path)?;
+    pub fn from_file(
+        path: &Path,
+        lower_case: bool,
+    ) -> Result<ReformerTokenizer, TokenizerError> {
+        let vocab = ReformerVocab::from_file(&path)?;
         let bpe_ranks = BpePairVocab::from_sentencepiece_file(path)?;
         let cache = RwLock::new(HashMap::new());
         Ok(ReformerTokenizer {
@@ -81,9 +85,9 @@ impl ReformerTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<ReformerTokenizer, TokenizerError> {
         let vocab =
             ReformerVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -48,7 +48,10 @@ impl ReformerTokenizer {
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<ReformerTokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
+        lower_case: bool,
+    ) -> Result<ReformerTokenizer, TokenizerError> {
         let vocab = ReformerVocab::from_file(&path)?;
         let bpe_ranks = BpePairVocab::from_sentencepiece_file(path)?;
         let cache = RwLock::new(HashMap::new());

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -45,10 +45,8 @@ impl ReformerTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
-    ///
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let tokenizer = SentencePieceTokenizer::from_file(&path, lower_case).unwrap();
+    /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<ReformerTokenizer, TokenizerError> {
         let vocab = ReformerVocab::from_file(&path)?;
@@ -75,13 +73,11 @@ impl ReformerTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -74,9 +74,9 @@ impl RobertaTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file<P: AsRef<Path>, M: AsRef<Path>>(
+        vocab_path: P,
+        merges_path: M,
         lower_case: bool,
         add_prefix_space: bool,
     ) -> Result<RobertaTokenizer, TokenizerError> {

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -30,6 +30,7 @@ use itertools::Itertools;
 use regex::Regex;
 use std::collections::HashMap;
 use std::iter::Iterator;
+use std::path::Path;
 use std::sync::RwLock;
 
 /// # RoBERTa tokenizer
@@ -72,8 +73,8 @@ impl RobertaTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
         add_prefix_space: bool,
     ) -> Result<RobertaTokenizer, TokenizerError> {
@@ -108,23 +109,25 @@ impl RobertaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
+    /// use std::path::Path;
+    /// 
     /// let lower_case = false;
     /// let add_prefix_space = true;
     /// let tokenizer = RobertaTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
-    ///     "path/to/merges/file",
+    ///     Path::new("path/to/vocab/file"),
+    ///     Path::new("path/to/merges/file"),
     ///     lower_case,
     ///     add_prefix_space,
-    ///     "path/to/special/token/mapping/file",
+    ///     Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        vocab_path: &str,
-        merges_path: &str,
+        vocab_path: &Path,
+        merges_path: &Path,
         lower_case: bool,
         add_prefix_space: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<RobertaTokenizer, TokenizerError> {
         let vocab = RobertaVocab::from_file_with_special_token_mapping(
             vocab_path,

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -62,13 +62,11 @@ impl RobertaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let add_prefix_space = true;
     /// let tokenizer = RobertaTokenizer::from_file(
-    ///     &Path::new("path/to/vocab/file"),
-    ///     &Path::new("path/to/merges/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
     ///     lower_case,
     ///     add_prefix_space,
     /// )
@@ -111,25 +109,24 @@ impl RobertaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
-    /// use std::path::Path;
     ///
     /// let lower_case = false;
     /// let add_prefix_space = true;
     /// let tokenizer = RobertaTokenizer::from_file_with_special_token_mapping(
-    ///     Path::new("path/to/vocab/file"),
-    ///     Path::new("path/to/merges/file"),
+    ///     "path/to/vocab/file",
+    ///     "path/to/merges/file",
     ///     lower_case,
     ///     add_prefix_space,
-    ///     Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        vocab_path: &Path,
-        merges_path: &Path,
+    pub fn from_file_with_special_token_mapping<V: AsRef<Path>, M: AsRef<Path>, S: AsRef<Path>>(
+        vocab_path: V,
+        merges_path: M,
         lower_case: bool,
         add_prefix_space: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<RobertaTokenizer, TokenizerError> {
         let vocab = RobertaVocab::from_file_with_special_token_mapping(
             vocab_path,
@@ -164,12 +161,10 @@ impl RobertaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, RobertaVocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let add_prefix_space = true;
-    /// let vocab = RobertaVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
+    /// let vocab = RobertaVocab::from_file("path/to/vocab/file").unwrap();
+    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
     ///
     /// let tokenizer = RobertaTokenizer::from_existing_vocab_and_merges(
     ///     vocab,

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -62,11 +62,13 @@ impl RobertaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let add_prefix_space = true;
     /// let tokenizer = RobertaTokenizer::from_file(
-    ///     "path/to/vocab/file",
-    ///     "path/to/merges/file",
+    ///     &Path::new("path/to/vocab/file"),
+    ///     &Path::new("path/to/merges/file"),
     ///     lower_case,
     ///     add_prefix_space,
     /// )
@@ -110,7 +112,7 @@ impl RobertaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
     /// use std::path::Path;
-    /// 
+    ///
     /// let lower_case = false;
     /// let add_prefix_space = true;
     /// let tokenizer = RobertaTokenizer::from_file_with_special_token_mapping(
@@ -162,10 +164,12 @@ impl RobertaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{RobertaTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{BpePairVocab, RobertaVocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let add_prefix_space = true;
-    /// let vocab = RobertaVocab::from_file("path/to/vocab/file").unwrap();
-    /// let merges = BpePairVocab::from_file("path/to/merges/file").unwrap();
+    /// let vocab = RobertaVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let merges = BpePairVocab::from_file(&Path::new("path/to/merges/file")).unwrap();
     ///
     /// let tokenizer = RobertaTokenizer::from_existing_vocab_and_merges(
     ///     vocab,

--- a/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
@@ -45,11 +45,13 @@ impl SentencePieceBpeTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -82,8 +84,10 @@ impl SentencePieceBpeTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let tokenizer = SentencePieceTokenizer::from_file(&Path::new("path/to/vocab/file"), lower_case).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -111,9 +115,11 @@ impl SentencePieceBpeTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceBpeTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceBpeModel, SentencePieceVocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = SentencePieceVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceBpeModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = SentencePieceVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceBpeModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer =
     ///     SentencePieceBpeTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);

--- a/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::tokenization_utils::{clean_text, decompose_nfkc, is_whitespace, lowercase};
 use crate::tokenizer::{MultiThreadedTokenizer, Tokenizer};
@@ -52,9 +54,9 @@ impl SentencePieceBpeTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<SentencePieceBpeTokenizer, TokenizerError> {
         let model = SentencePieceBpeModel::from_file(path)?;
         let vocab = SentencePieceVocab::from_file_with_special_token_mapping(
@@ -84,10 +86,10 @@ impl SentencePieceBpeTokenizer {
     /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
     ) -> Result<SentencePieceBpeTokenizer, TokenizerError> {
-        let model = SentencePieceBpeModel::from_file(path)?;
+        let model = SentencePieceBpeModel::from_file(&path)?;
         let vocab = SentencePieceVocab::from_file(path)?;
         Ok(SentencePieceBpeTokenizer {
             model,

--- a/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
@@ -55,12 +55,12 @@ impl SentencePieceBpeTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<SentencePieceBpeTokenizer, TokenizerError> {
-        let model = SentencePieceBpeModel::from_file(path)?;
+        let model = SentencePieceBpeModel::from_file(&path)?;
         let vocab = SentencePieceVocab::from_file_with_special_token_mapping(
             path,
             special_token_mapping_path,
@@ -89,8 +89,8 @@ impl SentencePieceBpeTokenizer {
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file(&Path::new("path/to/vocab/file"), lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
     ) -> Result<SentencePieceBpeTokenizer, TokenizerError> {
         let model = SentencePieceBpeModel::from_file(&path)?;

--- a/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
@@ -45,13 +45,11 @@ impl SentencePieceBpeTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -84,10 +82,8 @@ impl SentencePieceBpeTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let tokenizer = SentencePieceTokenizer::from_file(&Path::new("path/to/vocab/file"), lower_case).unwrap();
+    /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -115,11 +111,9 @@ impl SentencePieceBpeTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceBpeTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceBpeModel, SentencePieceVocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = SentencePieceVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceBpeModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = SentencePieceVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceBpeModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer =
     ///     SentencePieceBpeTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -44,8 +44,10 @@ impl SentencePieceTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let tokenizer = SentencePieceTokenizer::from_file(&Path::new("path/to/vocab/file"), lower_case).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -73,11 +75,13 @@ impl SentencePieceTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -110,9 +114,11 @@ impl SentencePieceTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, SentencePieceVocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = SentencePieceVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = SentencePieceVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = SentencePieceTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -44,10 +44,8 @@ impl SentencePieceTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let tokenizer = SentencePieceTokenizer::from_file(&Path::new("path/to/vocab/file"), lower_case).unwrap();
+    /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -75,13 +73,11 @@ impl SentencePieceTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -114,11 +110,9 @@ impl SentencePieceTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{SentencePieceTokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, SentencePieceVocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = SentencePieceVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = SentencePieceVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = SentencePieceTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -49,8 +49,8 @@ impl SentencePieceTokenizer {
     /// let lower_case = false;
     /// let tokenizer = SentencePieceTokenizer::from_file(&Path::new("path/to/vocab/file"), lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
     ) -> Result<SentencePieceTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
@@ -85,12 +85,12 @@ impl SentencePieceTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<SentencePieceTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = SentencePieceVocab::from_file_with_special_token_mapping(
             path,
             special_token_mapping_path,

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{Token, TokenRef};
 use crate::tokenizer::tokenization_utils::{clean_text, lowercase};
@@ -46,10 +48,10 @@ impl SentencePieceTokenizer {
     /// let tokenizer = SentencePieceTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
     ) -> Result<SentencePieceTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = SentencePieceVocab::from_file(path)?;
         Ok(SentencePieceTokenizer {
             model,
@@ -80,9 +82,9 @@ impl SentencePieceTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<SentencePieceTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab = SentencePieceVocab::from_file_with_special_token_mapping(

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::tokenization_utils::{
     clean_text, decompose_nfkc, is_whitespace, lowercase, split_on_special_tokens,
@@ -47,8 +49,11 @@ impl T5Tokenizer {
     /// let lower_case = false;
     /// let tokenizer = T5Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &str, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+    pub fn from_file(
+        path: &Path,
+        lower_case: bool,
+    ) -> Result<T5Tokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = T5Vocab::from_file(path)?;
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
         Ok(T5Tokenizer {
@@ -79,9 +84,9 @@ impl T5Tokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab =

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -46,13 +46,12 @@ impl T5Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
+    ///
     /// let lower_case = false;
-    /// let tokenizer = T5Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let tokenizer = T5Tokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
-        lower_case: bool,
-    ) -> Result<T5Tokenizer, TokenizerError> {
+    pub fn from_file(path: &Path, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = T5Vocab::from_file(path)?;
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
@@ -75,11 +74,13 @@ impl T5Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = T5Tokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -112,9 +113,11 @@ impl T5Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, T5Vocab, Vocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = T5Vocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = T5Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = T5Tokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -49,7 +49,10 @@ impl T5Tokenizer {
     /// let lower_case = false;
     /// let tokenizer = T5Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
+        lower_case: bool,
+    ) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = T5Vocab::from_file(path)?;
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -51,7 +51,7 @@ impl T5Tokenizer {
     /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = T5Tokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &Path, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = T5Vocab::from_file(path)?;
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
@@ -84,12 +84,12 @@ impl T5Tokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<T5Tokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab =
             T5Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -46,10 +46,8 @@ impl T5Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
-    ///
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let tokenizer = T5Tokenizer::from_file(&path, lower_case).unwrap();
+    /// let tokenizer = T5Tokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
@@ -74,13 +72,11 @@ impl T5Tokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = T5Tokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -113,11 +109,9 @@ impl T5Tokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{T5Tokenizer, Tokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, T5Vocab, Vocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = T5Vocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = T5Vocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = T5Tokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -47,14 +47,13 @@ impl XLMRobertaTokenizer {
     /// # Example
     ///
     /// ```no_run
-    /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
+    /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer}
+    /// ;
     /// let lower_case = false;
-    /// let tokenizer = XLMRobertaTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
+    /// let path = std::path::Path::new("path/to/vocab/file");
+    /// let tokenizer = XLMRobertaTokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
-        lower_case: bool,
-    ) -> Result<XLMRobertaTokenizer, TokenizerError> {
+    pub fn from_file(path: &Path, lower_case: bool) -> Result<XLMRobertaTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab = XLMRobertaVocab::from_file(path)?;
         Ok(XLMRobertaTokenizer {
@@ -76,11 +75,13 @@ impl XLMRobertaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let tokenizer = XLMRobertaTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -113,9 +114,11 @@ impl XLMRobertaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, Vocab, XLMRobertaVocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
-    /// let vocab = XLMRobertaVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = XLMRobertaVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer = XLMRobertaTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{
     Mask, Offset, OffsetSize, Token, TokenIdsWithOffsets, TokenIdsWithSpecialTokens, TokenRef,
@@ -49,7 +51,10 @@ impl XLMRobertaTokenizer {
     /// let lower_case = false;
     /// let tokenizer = XLMRobertaTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &str, lower_case: bool) -> Result<XLMRobertaTokenizer, TokenizerError> {
+    pub fn from_file(
+        path: &Path,
+        lower_case: bool,
+    ) -> Result<XLMRobertaTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab = XLMRobertaVocab::from_file(path)?;
         Ok(XLMRobertaTokenizer {
@@ -80,9 +85,9 @@ impl XLMRobertaTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<XLMRobertaTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab = XLMRobertaVocab::from_file_with_special_token_mapping(

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -53,8 +53,8 @@ impl XLMRobertaTokenizer {
     /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer = XLMRobertaTokenizer::from_file(&path, lower_case).unwrap();
     /// ```
-    pub fn from_file(path: &Path, lower_case: bool) -> Result<XLMRobertaTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<XLMRobertaTokenizer, TokenizerError> {
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = XLMRobertaVocab::from_file(path)?;
         Ok(XLMRobertaTokenizer {
             model,
@@ -85,12 +85,12 @@ impl XLMRobertaTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<XLMRobertaTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = XLMRobertaVocab::from_file_with_special_token_mapping(
             path,
             special_token_mapping_path,

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -47,11 +47,9 @@ impl XLMRobertaTokenizer {
     /// # Example
     ///
     /// ```no_run
-    /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer}
-    /// ;
+    /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
     /// let lower_case = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
-    /// let tokenizer = XLMRobertaTokenizer::from_file(&path, lower_case).unwrap();
+    /// let tokenizer = XLMRobertaTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<XLMRobertaTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
@@ -75,13 +73,11 @@ impl XLMRobertaTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let tokenizer = XLMRobertaTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -114,11 +110,9 @@ impl XLMRobertaTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLMRobertaTokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, Vocab, XLMRobertaVocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
-    /// let vocab = XLMRobertaVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = XLMRobertaVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer = XLMRobertaTokenizer::from_existing_vocab_and_model(vocab, model, lower_case);
     /// ```

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -51,7 +51,10 @@ impl XLMRobertaTokenizer {
     /// let lower_case = false;
     /// let tokenizer = XLMRobertaTokenizer::from_file("path/to/vocab/file", lower_case).unwrap();
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P, lower_case: bool) -> Result<XLMRobertaTokenizer, TokenizerError> {
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
+        lower_case: bool,
+    ) -> Result<XLMRobertaTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
         let vocab = XLMRobertaVocab::from_file(path)?;
         Ok(XLMRobertaTokenizer {

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -51,10 +51,12 @@ impl XLNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
+    ///
     /// let lower_case = false;
     /// let strip_accents = false;
+    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     XLNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
+    ///     XLNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
         path: &Path,
@@ -84,13 +86,15 @@ impl XLNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let strip_accents = false;
     /// let tokenizer = XLNetTokenizer::from_file_with_special_token_mapping(
-    ///     "path/to/vocab/file",
+    ///     &Path::new("path/to/vocab/file"),
     ///     lower_case,
     ///     strip_accents,
-    ///     "path/to/special/token/mapping/file",
+    ///     &Path::new("path/to/special/token/mapping/file"),
     /// )
     /// .unwrap();
     /// ```
@@ -124,10 +128,12 @@ impl XLNetTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, Vocab, XLNetVocab};
+    /// use std::path::Path;
+    ///
     /// let lower_case = false;
     /// let strip_accents = false;
-    /// let vocab = XLNetVocab::from_file("path/to/vocab/file").unwrap();
-    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
+    /// let vocab = XLNetVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
+    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
     ///
     /// let tokenizer =
     ///     XLNetTokenizer::from_existing_vocab_and_model(vocab, model, lower_case, strip_accents);

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -58,12 +58,12 @@ impl XLNetTokenizer {
     /// let tokenizer =
     ///     XLNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
     /// ```
-    pub fn from_file(
-        path: &Path,
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<XLNetTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab = XLNetVocab::from_file(path)?;
         Ok(XLNetTokenizer {
             model,
@@ -98,13 +98,13 @@ impl XLNetTokenizer {
     /// )
     /// .unwrap();
     /// ```
-    pub fn from_file_with_special_token_mapping(
-        path: &Path,
+    pub fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &Path,
+        special_token_mapping_path: S,
     ) -> Result<XLNetTokenizer, TokenizerError> {
-        let model = SentencePieceModel::from_file(path)?;
+        let model = SentencePieceModel::from_file(&path)?;
         let vocab =
             XLNetVocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
         Ok(XLNetTokenizer {

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -51,12 +51,10 @@ impl XLNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
-    ///
     /// let lower_case = false;
     /// let strip_accents = false;
-    /// let path = std::path::Path::new("path/to/vocab/file");
     /// let tokenizer =
-    ///     XLNetTokenizer::from_file(&path, lower_case, strip_accents).unwrap();
+    ///     XLNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file<P: AsRef<Path>>(
         path: P,
@@ -86,15 +84,13 @@ impl XLNetTokenizer {
     ///
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let strip_accents = false;
     /// let tokenizer = XLNetTokenizer::from_file_with_special_token_mapping(
-    ///     &Path::new("path/to/vocab/file"),
+    ///     "path/to/vocab/file",
     ///     lower_case,
     ///     strip_accents,
-    ///     &Path::new("path/to/special/token/mapping/file"),
+    ///     "path/to/special/token/mapping/file",
     /// )
     /// .unwrap();
     /// ```
@@ -128,12 +124,10 @@ impl XLNetTokenizer {
     /// ```no_run
     /// use rust_tokenizers::tokenizer::{Tokenizer, XLNetTokenizer};
     /// use rust_tokenizers::vocab::{SentencePieceModel, Vocab, XLNetVocab};
-    /// use std::path::Path;
-    ///
     /// let lower_case = false;
     /// let strip_accents = false;
-    /// let vocab = XLNetVocab::from_file(&Path::new("path/to/vocab/file")).unwrap();
-    /// let model = SentencePieceModel::from_file(&Path::new("path/to/model/file")).unwrap();
+    /// let vocab = XLNetVocab::from_file("path/to/vocab/file").unwrap();
+    /// let model = SentencePieceModel::from_file("path/to/model/file").unwrap();
     ///
     /// let tokenizer =
     ///     XLNetTokenizer::from_existing_vocab_and_model(vocab, model, lower_case, strip_accents);

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::error::TokenizerError;
 use crate::tokenizer::base_tokenizer::{TokenIdsWithOffsets, TokenIdsWithSpecialTokens};
 use crate::tokenizer::tokenization_utils::strip_accents;
@@ -55,7 +57,7 @@ impl XLNetTokenizer {
     ///     XLNetTokenizer::from_file("path/to/vocab/file", lower_case, strip_accents).unwrap();
     /// ```
     pub fn from_file(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
     ) -> Result<XLNetTokenizer, TokenizerError> {
@@ -93,10 +95,10 @@ impl XLNetTokenizer {
     /// .unwrap();
     /// ```
     pub fn from_file_with_special_token_mapping(
-        path: &str,
+        path: &Path,
         lower_case: bool,
         strip_accents: bool,
-        special_token_mapping_path: &str,
+        special_token_mapping_path: &Path,
     ) -> Result<XLNetTokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(path)?;
         let vocab =

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -123,8 +123,8 @@ impl Vocab for AlbertVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<AlbertVocab, TokenizerError> {
-        let values = read_protobuf_file(path)?;
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<AlbertVocab, TokenizerError> {
+        let values = read_protobuf_file(path.as_ref())?;
 
         let special_token_map = SpecialTokenMap {
             unk_token: DEFAULT_UNK_TOKEN.to_string(),
@@ -139,9 +139,9 @@ impl Vocab for AlbertVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -18,6 +18,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # AlbertVocab
 /// Vocabulary for ALBERT tokenizer. Contains the following special values:
@@ -122,7 +123,7 @@ impl Vocab for AlbertVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<AlbertVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<AlbertVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -139,8 +140,8 @@ impl Vocab for AlbertVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -30,7 +30,9 @@ pub(crate) fn swap_key_values<T: Clone, U: Hash + Eq + Copy>(
 
 /// Read a flat vocab.txt file (single column, one token per line)
 /// Indices are inferred based on their position in this flat file.
-pub(crate) fn read_flat_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_flat_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<HashMap<String, i64>, TokenizerError> {
     let f = File::open(&path).map_err(|e| {
         TokenizerError::FileNotFound(format!(
             "{} vocabulary file not found :{}",
@@ -54,7 +56,9 @@ pub(crate) fn read_flat_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, 
 }
 
 /// Read a json file (mapping of vocabulary to indices).
-pub(crate) fn read_json_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_json_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<HashMap<String, i64>, TokenizerError> {
     let f = File::open(&path).map_err(|e| {
         TokenizerError::FileNotFound(format!(
             "{} vocabulary file not found :{}",
@@ -96,7 +100,9 @@ pub(crate) fn open_protobuf_file<P: AsRef<Path>>(path: P) -> Result<ModelProto, 
 }
 
 /// Read a SentencePiece protobuf file and extract vocabulary from it.
-pub(crate) fn read_protobuf_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_protobuf_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<HashMap<String, i64>, TokenizerError> {
     let proto = open_protobuf_file(path)?;
 
     let mut values = HashMap::new();

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -220,9 +220,9 @@ pub trait Vocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
-    /// let path = "path/to/file";
     ///
-    /// let base_vocab = BertVocab::from_file(&std::path::Path::new(path));
+    /// let path = std::path::Path::new("path/to/file");
+    /// let base_vocab = BertVocab::from_file(&path);
     /// ```
     fn from_file(path: &Path) -> Result<Self, TokenizerError>
     where
@@ -234,10 +234,12 @@ pub trait Vocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
-    /// let path = "path/to/file";
-    /// let special_token_mapping = "path/to/mapping.json";
+    /// use std::path::Path;
     ///
-    /// let base_vocab = BertVocab::from_file_with_special_token_mapping(path, special_token_mapping);
+    /// let path = Path::new("path/to/file");
+    /// let special_token_mapping = Path::new("path/to/mapping.json");
+    ///
+    /// let base_vocab = BertVocab::from_file_with_special_token_mapping(&path, &special_token_mapping);
     /// ```
     fn from_file_with_special_token_mapping(
         path: &Path,

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -30,11 +30,11 @@ pub(crate) fn swap_key_values<T: Clone, U: Hash + Eq + Copy>(
 
 /// Read a flat vocab.txt file (single column, one token per line)
 /// Indices are inferred based on their position in this flat file.
-pub(crate) fn read_flat_file(path: &Path) -> Result<HashMap<String, i64>, TokenizerError> {
-    let f = File::open(path).map_err(|e| {
+pub(crate) fn read_flat_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, i64>, TokenizerError> {
+    let f = File::open(&path).map_err(|e| {
         TokenizerError::FileNotFound(format!(
             "{} vocabulary file not found :{}",
-            path.display(),
+            path.as_ref().display(),
             e
         ))
     })?;
@@ -54,11 +54,11 @@ pub(crate) fn read_flat_file(path: &Path) -> Result<HashMap<String, i64>, Tokeni
 }
 
 /// Read a json file (mapping of vocabulary to indices).
-pub(crate) fn read_json_file(path: &Path) -> Result<HashMap<String, i64>, TokenizerError> {
-    let f = File::open(path).map_err(|e| {
+pub(crate) fn read_json_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, i64>, TokenizerError> {
+    let f = File::open(&path).map_err(|e| {
         TokenizerError::FileNotFound(format!(
             "{} vocabulary file not found :{}",
-            path.display(),
+            path.as_ref().display(),
             e
         ))
     })?;
@@ -72,11 +72,11 @@ pub(crate) fn read_json_file(path: &Path) -> Result<HashMap<String, i64>, Tokeni
     Ok(values)
 }
 
-pub(crate) fn open_protobuf_file(path: &Path) -> Result<ModelProto, TokenizerError> {
-    let mut f = File::open(path).map_err(|e| {
+pub(crate) fn open_protobuf_file<P: AsRef<Path>>(path: P) -> Result<ModelProto, TokenizerError> {
+    let mut f = File::open(&path).map_err(|e| {
         TokenizerError::FileNotFound(format!(
             "{} vocabulary file not found :{}",
-            path.display(),
+            path.as_ref().display(),
             e
         ))
     })?;
@@ -96,7 +96,7 @@ pub(crate) fn open_protobuf_file(path: &Path) -> Result<ModelProto, TokenizerErr
 }
 
 /// Read a SentencePiece protobuf file and extract vocabulary from it.
-pub(crate) fn read_protobuf_file(path: &Path) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_protobuf_file<P: AsRef<Path>>(path: P) -> Result<HashMap<String, i64>, TokenizerError> {
     let proto = open_protobuf_file(path)?;
 
     let mut values = HashMap::new();
@@ -108,13 +108,13 @@ pub(crate) fn read_protobuf_file(path: &Path) -> Result<HashMap<String, i64>, To
 
 /// Read a special token mapping file (expects a JSON-like file with key-value pairs
 /// corresponding to the special token names and values).
-pub(crate) fn read_special_token_mapping_file(
-    path: &Path,
+pub(crate) fn read_special_token_mapping_file<P: AsRef<Path>>(
+    path: P,
 ) -> Result<SpecialTokenMap, TokenizerError> {
-    let f = File::open(path).map_err(|e| {
+    let f = File::open(&path).map_err(|e| {
         TokenizerError::FileNotFound(format!(
             "{} vocabulary file not found :{}",
-            path.display(),
+            path.as_ref().display(),
             e
         ))
     })?;
@@ -224,7 +224,7 @@ pub trait Vocab {
     /// let path = std::path::Path::new("path/to/file");
     /// let base_vocab = BertVocab::from_file(&path);
     /// ```
-    fn from_file(path: &Path) -> Result<Self, TokenizerError>
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, TokenizerError>
     where
         Self: Sized;
 
@@ -241,9 +241,9 @@ pub trait Vocab {
     ///
     /// let base_vocab = BertVocab::from_file_with_special_token_mapping(&path, &special_token_mapping);
     /// ```
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError>
     where
         Self: Sized;
@@ -389,7 +389,7 @@ impl Vocab for BaseVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<BaseVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<BaseVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {
             unk_token: DEFAULT_UNK_TOKEN.to_string(),
@@ -404,9 +404,9 @@ impl Vocab for BaseVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::hash::Hash;
 use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
 
 pub(crate) fn swap_key_values<T: Clone, U: Hash + Eq + Copy>(
     input_hashmap: &HashMap<T, U>,
@@ -29,9 +30,13 @@ pub(crate) fn swap_key_values<T: Clone, U: Hash + Eq + Copy>(
 
 /// Read a flat vocab.txt file (single column, one token per line)
 /// Indices are inferred based on their position in this flat file.
-pub(crate) fn read_flat_file(path: &str) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_flat_file(path: &Path) -> Result<HashMap<String, i64>, TokenizerError> {
     let f = File::open(path).map_err(|e| {
-        TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+        TokenizerError::FileNotFound(format!(
+            "{} vocabulary file not found :{}",
+            path.display(),
+            e
+        ))
     })?;
     let br = BufReader::new(f);
     let mut data = HashMap::new();
@@ -49,9 +54,13 @@ pub(crate) fn read_flat_file(path: &str) -> Result<HashMap<String, i64>, Tokeniz
 }
 
 /// Read a json file (mapping of vocabulary to indices).
-pub(crate) fn read_json_file(path: &str) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_json_file(path: &Path) -> Result<HashMap<String, i64>, TokenizerError> {
     let f = File::open(path).map_err(|e| {
-        TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+        TokenizerError::FileNotFound(format!(
+            "{} vocabulary file not found :{}",
+            path.display(),
+            e
+        ))
     })?;
     let br = BufReader::new(f);
     let values: HashMap<String, i64> = match serde_json::from_reader(br) {
@@ -63,9 +72,13 @@ pub(crate) fn read_json_file(path: &str) -> Result<HashMap<String, i64>, Tokeniz
     Ok(values)
 }
 
-pub(crate) fn open_protobuf_file(path: &str) -> Result<ModelProto, TokenizerError> {
+pub(crate) fn open_protobuf_file(path: &Path) -> Result<ModelProto, TokenizerError> {
     let mut f = File::open(path).map_err(|e| {
-        TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+        TokenizerError::FileNotFound(format!(
+            "{} vocabulary file not found :{}",
+            path.display(),
+            e
+        ))
     })?;
     let mut contents = Vec::new();
     let proto = match f.read_to_end(&mut contents) {
@@ -83,7 +96,7 @@ pub(crate) fn open_protobuf_file(path: &str) -> Result<ModelProto, TokenizerErro
 }
 
 /// Read a SentencePiece protobuf file and extract vocabulary from it.
-pub(crate) fn read_protobuf_file(path: &str) -> Result<HashMap<String, i64>, TokenizerError> {
+pub(crate) fn read_protobuf_file(path: &Path) -> Result<HashMap<String, i64>, TokenizerError> {
     let proto = open_protobuf_file(path)?;
 
     let mut values = HashMap::new();
@@ -96,10 +109,14 @@ pub(crate) fn read_protobuf_file(path: &str) -> Result<HashMap<String, i64>, Tok
 /// Read a special token mapping file (expects a JSON-like file with key-value pairs
 /// corresponding to the special token names and values).
 pub(crate) fn read_special_token_mapping_file(
-    path: &str,
+    path: &Path,
 ) -> Result<SpecialTokenMap, TokenizerError> {
     let f = File::open(path).map_err(|e| {
-        TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+        TokenizerError::FileNotFound(format!(
+            "{} vocabulary file not found :{}",
+            path.display(),
+            e
+        ))
     })?;
     let br = BufReader::new(f);
     serde_json::from_reader(br).map_err(|e| {
@@ -205,9 +222,9 @@ pub trait Vocab {
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
     /// let path = "path/to/file";
     ///
-    /// let base_vocab = BertVocab::from_file(path);
+    /// let base_vocab = BertVocab::from_file(&std::path::Path::new(path));
     /// ```
-    fn from_file(path: &str) -> Result<Self, TokenizerError>
+    fn from_file(path: &Path) -> Result<Self, TokenizerError>
     where
         Self: Sized;
 
@@ -223,8 +240,8 @@ pub trait Vocab {
     /// let base_vocab = BertVocab::from_file_with_special_token_mapping(path, special_token_mapping);
     /// ```
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError>
     where
         Self: Sized;
@@ -370,7 +387,7 @@ impl Vocab for BaseVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<BaseVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<BaseVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {
             unk_token: DEFAULT_UNK_TOKEN.to_string(),
@@ -386,8 +403,8 @@ impl Vocab for BaseVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
@@ -497,7 +514,7 @@ mod tests {
             [("[UNK]".to_owned(), 2)].iter().cloned().collect();
 
         //        When
-        let base_vocab = BaseVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let base_vocab = BaseVocab::from_file(&path)?;
 
         //        Then
         assert_eq!(base_vocab.get_unknown_value(), "[UNK]");
@@ -516,7 +533,7 @@ mod tests {
         let path = vocab_file.into_temp_path();
 
         //        When & Then
-        let _base_vocab = BaseVocab::from_file(path.to_path_buf().to_str().unwrap()).unwrap();
+        let _base_vocab = BaseVocab::from_file(&path).unwrap();
     }
 
     #[test]
@@ -525,7 +542,7 @@ mod tests {
         let mut vocab_file = tempfile::NamedTempFile::new()?;
         write!(vocab_file, "hello \n world \n [UNK] \n !")?;
         let path = vocab_file.into_temp_path();
-        let base_vocab = BaseVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let base_vocab = BaseVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(base_vocab.token_to_id("hello"), 0);
@@ -544,7 +561,7 @@ mod tests {
         let mut vocab_file = tempfile::NamedTempFile::new()?;
         write!(vocab_file, "hello \n world \n [UNK] \n !")?;
         let path = vocab_file.into_temp_path();
-        let base_vocab = BaseVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let base_vocab = BaseVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(base_vocab.id_to_token(&(0_i64)), "hello");

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -220,9 +220,9 @@ pub trait Vocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
+    /// let path = "path/to/file";
     ///
-    /// let path = std::path::Path::new("path/to/file");
-    /// let base_vocab = BertVocab::from_file(&path);
+    /// let base_vocab = BertVocab::from_file(path);
     /// ```
     fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, TokenizerError>
     where
@@ -234,12 +234,10 @@ pub trait Vocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BertVocab, Vocab};
-    /// use std::path::Path;
+    /// let path = "path/to/file";
+    /// let special_token_mapping = "path/to/mapping.json";
     ///
-    /// let path = Path::new("path/to/file");
-    /// let special_token_mapping = Path::new("path/to/mapping.json");
-    ///
-    /// let base_vocab = BertVocab::from_file_with_special_token_mapping(&path, &special_token_mapping);
+    /// let base_vocab = BertVocab::from_file_with_special_token_mapping(path, special_token_mapping);
     /// ```
     fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
         path: P,

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -243,7 +243,7 @@ mod tests {
         .collect();
 
         //        When
-        let bert_vocab = BertVocab::from_file(&path)?;
+        let bert_vocab = BertVocab::from_file(&path )?;
 
         //        Then
         assert_eq!(bert_vocab.get_unknown_value(), "[UNK]");

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
     read_flat_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # BERT Vocab
 /// Vocabulary for BERT tokenizer. Contains the following special values:
@@ -102,7 +103,7 @@ impl Vocab for BertVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<BertVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<BertVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {
             unk_token: DEFAULT_UNK_TOKEN.to_string(),
@@ -118,8 +119,8 @@ impl Vocab for BertVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
@@ -242,7 +243,7 @@ mod tests {
         .collect();
 
         //        When
-        let bert_vocab = BertVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let bert_vocab = BertVocab::from_file(&path )?;
 
         //        Then
         assert_eq!(bert_vocab.get_unknown_value(), "[UNK]");
@@ -261,7 +262,7 @@ mod tests {
         let path = vocab_file.into_temp_path();
 
         //        When & Then
-        let _base_vocab = BertVocab::from_file(path.to_path_buf().to_str().unwrap()).unwrap();
+        let _base_vocab = BertVocab::from_file(&path).unwrap();
     }
 
     #[test]
@@ -273,7 +274,7 @@ mod tests {
             "hello \n world \n [UNK] \n ! \n [CLS] \n [SEP] \n [MASK] \n [PAD]"
         )?;
         let path = vocab_file.into_temp_path();
-        let base_vocab = BertVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let base_vocab = BertVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(base_vocab.token_to_id("hello"), 0);
@@ -299,7 +300,7 @@ mod tests {
             "hello \n world \n [UNK] \n ! \n [CLS] \n [SEP] \n [MASK] \n [PAD]"
         )?;
         let path = vocab_file.into_temp_path();
-        let bert_vocab = BertVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let bert_vocab = BertVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(bert_vocab.id_to_token(&(0_i64)), "hello");

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -103,7 +103,7 @@ impl Vocab for BertVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<BertVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<BertVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {
             unk_token: DEFAULT_UNK_TOKEN.to_string(),
@@ -118,9 +118,9 @@ impl Vocab for BertVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -243,7 +243,7 @@ mod tests {
         .collect();
 
         //        When
-        let bert_vocab = BertVocab::from_file(&path )?;
+        let bert_vocab = BertVocab::from_file(&path)?;
 
         //        Then
         assert_eq!(bert_vocab.get_unknown_value(), "[UNK]");

--- a/main/src/vocab/bpe_vocab.rs
+++ b/main/src/vocab/bpe_vocab.rs
@@ -50,11 +50,11 @@ impl BpePairVocab {
     /// let path = std::path::Path::new("path/to/file");
     /// let bpe_vocab = BpePairVocab::from_file(&path);
     /// ```
-    pub fn from_file(path: &Path) -> Result<BpePairVocab, TokenizerError> {
-        let f = File::open(path).map_err(|e| {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<BpePairVocab, TokenizerError> {
+        let f = File::open(&path).map_err(|e| {
             TokenizerError::FileNotFound(format!(
                 "{} vocabulary file not found :{}",
-                path.display(),
+                path.as_ref().display(),
                 e
             ))
         })?;
@@ -88,11 +88,11 @@ impl BpePairVocab {
     /// let path = std::path::Path::new("path/to/spiece.model");
     /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(&path);
     /// ```
-    pub fn from_sentencepiece_file(path: &Path) -> Result<BpePairVocab, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
+    pub fn from_sentencepiece_file<P: AsRef<Path>>(path: P) -> Result<BpePairVocab, TokenizerError> {
+        let mut f = File::open(&path).map_err(|e| {
             TokenizerError::FileNotFound(format!(
                 "{} vocabulary file not found :{}",
-                path.display(),
+                path.as_ref().display(),
                 e
             ))
         })?;

--- a/main/src/vocab/bpe_vocab.rs
+++ b/main/src/vocab/bpe_vocab.rs
@@ -46,9 +46,9 @@ impl BpePairVocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BpePairVocab, Vocab};
-    /// let path = "path/to/file";
     ///
-    /// let bpe_vocab = BpePairVocab::from_file(&std::path::Path::new(path));
+    /// let path = std::path::Path::new("path/to/file");
+    /// let bpe_vocab = BpePairVocab::from_file(&path);
     /// ```
     pub fn from_file(path: &Path) -> Result<BpePairVocab, TokenizerError> {
         let f = File::open(path).map_err(|e| {
@@ -84,9 +84,9 @@ impl BpePairVocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BpePairVocab, Vocab};
-    /// let path = "path/to/spiece.model";
     ///
-    /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(path);
+    /// let path = std::path::Path::new("path/to/spiece.model");
+    /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(&path);
     /// ```
     pub fn from_sentencepiece_file(path: &Path) -> Result<BpePairVocab, TokenizerError> {
         let mut f = File::open(path).map_err(|e| {

--- a/main/src/vocab/bpe_vocab.rs
+++ b/main/src/vocab/bpe_vocab.rs
@@ -88,7 +88,9 @@ impl BpePairVocab {
     ///
     /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(path);
     /// ```
-    pub fn from_sentencepiece_file<P: AsRef<Path>>(path: P) -> Result<BpePairVocab, TokenizerError> {
+    pub fn from_sentencepiece_file<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<BpePairVocab, TokenizerError> {
         let mut f = File::open(&path).map_err(|e| {
             TokenizerError::FileNotFound(format!(
                 "{} vocabulary file not found :{}",

--- a/main/src/vocab/bpe_vocab.rs
+++ b/main/src/vocab/bpe_vocab.rs
@@ -46,9 +46,9 @@ impl BpePairVocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BpePairVocab, Vocab};
+    /// let path = "path/to/file";
     ///
-    /// let path = std::path::Path::new("path/to/file");
-    /// let bpe_vocab = BpePairVocab::from_file(&path);
+    /// let bpe_vocab = BpePairVocab::from_file(path);
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<BpePairVocab, TokenizerError> {
         let f = File::open(&path).map_err(|e| {
@@ -84,9 +84,9 @@ impl BpePairVocab {
     ///
     /// ```no_run
     /// use rust_tokenizers::vocab::{BpePairVocab, Vocab};
+    /// let path = "path/to/spiece.model";
     ///
-    /// let path = std::path::Path::new("path/to/spiece.model");
-    /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(&path);
+    /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(path);
     /// ```
     pub fn from_sentencepiece_file<P: AsRef<Path>>(path: P) -> Result<BpePairVocab, TokenizerError> {
         let mut f = File::open(&path).map_err(|e| {
@@ -134,7 +134,7 @@ impl BpePairVocab {
     /// use rust_tokenizers::vocab::{BpePairRef, BpePairVocab, Vocab};
     /// let path = "path/to/file";
     ///
-    /// let bpe_vocab = BpePairVocab::from_file(&std::path::Path::new(path)).unwrap();
+    /// let bpe_vocab = BpePairVocab::from_file(path).unwrap();
     ///
     /// let query = BpePairRef {
     ///     byte_1: &"won".to_string(),

--- a/main/src/vocab/bpe_vocab.rs
+++ b/main/src/vocab/bpe_vocab.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::mem::ManuallyDrop;
+use std::path::Path;
 use std::ptr;
 
 /// # Byte pair query
@@ -47,11 +48,15 @@ impl BpePairVocab {
     /// use rust_tokenizers::vocab::{BpePairVocab, Vocab};
     /// let path = "path/to/file";
     ///
-    /// let bpe_vocab = BpePairVocab::from_file(path);
+    /// let bpe_vocab = BpePairVocab::from_file(&std::path::Path::new(path));
     /// ```
-    pub fn from_file(path: &str) -> Result<BpePairVocab, TokenizerError> {
+    pub fn from_file(path: &Path) -> Result<BpePairVocab, TokenizerError> {
         let f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+            TokenizerError::FileNotFound(format!(
+                "{} vocabulary file not found :{}",
+                path.display(),
+                e
+            ))
         })?;
         let br = BufReader::new(f);
         let mut data = HashMap::new();
@@ -83,9 +88,13 @@ impl BpePairVocab {
     ///
     /// let bpe_vocab = BpePairVocab::from_sentencepiece_file(path);
     /// ```
-    pub fn from_sentencepiece_file(path: &str) -> Result<BpePairVocab, TokenizerError> {
+    pub fn from_sentencepiece_file(path: &Path) -> Result<BpePairVocab, TokenizerError> {
         let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+            TokenizerError::FileNotFound(format!(
+                "{} vocabulary file not found :{}",
+                path.display(),
+                e
+            ))
         })?;
         let mut contents = Vec::new();
         let proto = match f.read_to_end(&mut contents) {
@@ -125,7 +134,7 @@ impl BpePairVocab {
     /// use rust_tokenizers::vocab::{BpePairRef, BpePairVocab, Vocab};
     /// let path = "path/to/file";
     ///
-    /// let bpe_vocab = BpePairVocab::from_file(path).unwrap();
+    /// let bpe_vocab = BpePairVocab::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let query = BpePairRef {
     ///     byte_1: &"won".to_string(),
@@ -185,7 +194,7 @@ mod tests {
         .collect();
 
         //        When
-        let pair_vocab = BpePairVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let pair_vocab = BpePairVocab::from_file(&path)?;
 
         //        Then
         assert_eq!(pair_vocab.values, target_values);
@@ -199,7 +208,7 @@ mod tests {
         let mut merges_file = tempfile::NamedTempFile::new()?;
         write!(merges_file, "#version: 0.1\n t h\na n\ni n\nth e</w>")?;
         let path = merges_file.into_temp_path();
-        let pair_vocab = BpePairVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let pair_vocab = BpePairVocab::from_file(&path)?;
 
         //        Given
         let t_token = String::from("t");

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -122,7 +122,7 @@ impl Vocab for DeBERTaV2Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<DeBERTaV2Vocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<DeBERTaV2Vocab, TokenizerError> {
         let mut values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -144,9 +144,9 @@ impl Vocab for DeBERTaV2Vocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let mut values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # DeBERTaV2Vocab
 /// Vocabulary for DeBERTa (v2) tokenizer. Contains the following special values:
@@ -121,7 +122,7 @@ impl Vocab for DeBERTaV2Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<DeBERTaV2Vocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<DeBERTaV2Vocab, TokenizerError> {
         let mut values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -144,8 +145,8 @@ impl Vocab for DeBERTaV2Vocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let mut values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/deberta_vocab.rs
+++ b/main/src/vocab/deberta_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
     read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # DeBERTa Vocab
 /// Vocabulary for DeBERTa tokenizer. Contains the following special values:
@@ -121,7 +122,7 @@ impl Vocab for DeBERTaVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<DeBERTaVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<DeBERTaVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -138,8 +139,8 @@ impl Vocab for DeBERTaVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/deberta_vocab.rs
+++ b/main/src/vocab/deberta_vocab.rs
@@ -122,7 +122,7 @@ impl Vocab for DeBERTaVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<DeBERTaVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<DeBERTaVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -138,9 +138,9 @@ impl Vocab for DeBERTaVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -105,7 +105,7 @@ impl Vocab for FNetVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<FNetVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<FNetVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -121,9 +121,9 @@ impl Vocab for FNetVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -18,6 +18,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # FNetVocab
 /// Vocabulary for FNet tokenizer. Contains the following special values:
@@ -104,7 +105,7 @@ impl Vocab for FNetVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<FNetVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<FNetVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -121,8 +122,8 @@ impl Vocab for FNetVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -85,7 +85,7 @@ impl Vocab for Gpt2Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<Gpt2Vocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<Gpt2Vocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -101,9 +101,9 @@ impl Vocab for Gpt2Vocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
     read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # GPT2 Vocab
 /// Vocabulary for GPT2 tokenizer. Contains the following special values:
@@ -84,7 +85,7 @@ impl Vocab for Gpt2Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<Gpt2Vocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<Gpt2Vocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -101,8 +102,8 @@ impl Vocab for Gpt2Vocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
@@ -220,7 +221,7 @@ mod tests {
             [("<|endoftext|>".to_owned(), 2)].iter().cloned().collect();
 
         //        When
-        let gpt2_vocab = Gpt2Vocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let gpt2_vocab = Gpt2Vocab::from_file(&path)?;
 
         //        Then
         assert_eq!(gpt2_vocab.special_token_map.unk_token, "<|endoftext|>");
@@ -239,7 +240,7 @@ mod tests {
         let path = vocab_file.into_temp_path();
 
         //        When & Then
-        let _ctrl_vocab = Gpt2Vocab::from_file(path.to_path_buf().to_str().unwrap()).unwrap();
+        let _ctrl_vocab = Gpt2Vocab::from_file(&path).unwrap();
     }
 
     #[test]
@@ -251,7 +252,7 @@ mod tests {
             "{{\"hello\": 1,\n \"world\": 0,\n \"<|endoftext|>\": 2,\n \"!\": 3\n}}"
         )?;
         let path = vocab_file.into_temp_path();
-        let gpt2_vocab = Gpt2Vocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let gpt2_vocab = Gpt2Vocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(gpt2_vocab.token_to_id("hello"), 1);
@@ -273,7 +274,7 @@ mod tests {
             "{{\"hello\": 1,\n \"world\": 0,\n \"<|endoftext|>\": 2,\n \"!\": 3\n}}"
         )?;
         let path = vocab_file.into_temp_path();
-        let gpt2_vocab = Gpt2Vocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let gpt2_vocab = Gpt2Vocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(gpt2_vocab.id_to_token(&(1_i64)), "hello");

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -17,6 +17,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 pub static FAIRSEQ_LANGUAGE_CODES: [&str; 100] = [
     "af", "am", "ar", "ast", "az", "ba", "be", "bg", "bn", "br", "bs", "ca", "ceb", "cs", "cy",
@@ -117,7 +118,7 @@ impl Vocab for M2M100Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<M2M100Vocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<M2M100Vocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -134,8 +135,8 @@ impl Vocab for M2M100Vocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -118,7 +118,7 @@ impl Vocab for M2M100Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<M2M100Vocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<M2M100Vocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -134,9 +134,9 @@ impl Vocab for M2M100Vocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -87,7 +87,7 @@ impl Vocab for MarianVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<MarianVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<MarianVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -103,9 +103,9 @@ impl Vocab for MarianVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -18,6 +18,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # Marian Vocab
 /// Vocabulary for Marian tokenizer. Contains the following special values:
@@ -86,7 +87,7 @@ impl Vocab for MarianVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<MarianVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<MarianVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -103,8 +104,8 @@ impl Vocab for MarianVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -17,6 +17,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 pub static FAIRSEQ_LANGUAGE_CODES: [&str; 52] = [
     ">>ar<<", ">>cs<<", ">>de<<", ">>en<<", ">>es<<", ">>et<<", ">>fi<<", ">>fr<<", ">>gu<<",
@@ -125,7 +126,7 @@ impl Vocab for MBart50Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<MBart50Vocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<MBart50Vocab, TokenizerError> {
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();
 
@@ -188,8 +189,8 @@ impl Vocab for MBart50Vocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -126,7 +126,7 @@ impl Vocab for MBart50Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<MBart50Vocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<MBart50Vocab, TokenizerError> {
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();
 
@@ -188,9 +188,9 @@ impl Vocab for MBart50Vocab {
         })
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -64,7 +64,7 @@ impl Vocab for OpenAiGptVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<OpenAiGptVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<OpenAiGptVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -80,9 +80,9 @@ impl Vocab for OpenAiGptVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
     read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # GPT Vocab
 /// Vocabulary for GPT tokenizer. Only contains the unknown token as a special value.
@@ -63,7 +64,7 @@ impl Vocab for OpenAiGptVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<OpenAiGptVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<OpenAiGptVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -80,8 +81,8 @@ impl Vocab for OpenAiGptVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
@@ -197,7 +198,7 @@ mod tests {
             [("<unk>".to_owned(), 2)].iter().cloned().collect();
 
         //        When
-        let openai_gpt_vocab = OpenAiGptVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let openai_gpt_vocab = OpenAiGptVocab::from_file(&path)?;
 
         //        Then
         assert_eq!(openai_gpt_vocab.get_unknown_value(), "<unk>");
@@ -216,7 +217,7 @@ mod tests {
         let path = vocab_file.into_temp_path();
 
         //        When & Then
-        let _ctrl_vocab = OpenAiGptVocab::from_file(path.to_path_buf().to_str().unwrap()).unwrap();
+        let _ctrl_vocab = OpenAiGptVocab::from_file(&path).unwrap();
     }
 
     #[test]
@@ -228,7 +229,7 @@ mod tests {
             "{{\"hello\": 1,\n \"world\": 0,\n \"<unk>\": 2,\n \"!\": 3\n}}"
         )?;
         let path = vocab_file.into_temp_path();
-        let openai_gpt_vocab = OpenAiGptVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let openai_gpt_vocab = OpenAiGptVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(openai_gpt_vocab.token_to_id("hello"), 1);
@@ -250,7 +251,7 @@ mod tests {
             "{{\"hello\": 1,\n \"world\": 0,\n \"<unk>\": 2,\n \"!\": 3\n}}"
         )?;
         let path = vocab_file.into_temp_path();
-        let openai_gpt_vocab = OpenAiGptVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let openai_gpt_vocab = OpenAiGptVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(openai_gpt_vocab.id_to_token(&(1_i64)), "hello");

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -18,6 +18,7 @@ use crate::vocab::base_vocab::{
 use crate::vocab::Vocab;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// # Pegasus Vocab
 /// Vocabulary for Pegasus tokenizer. Contains the following special values:
@@ -108,7 +109,7 @@ impl Vocab for PegasusVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<PegasusVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<PegasusVocab, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 
         let mut values = HashMap::new();
@@ -202,8 +203,8 @@ impl Vocab for PegasusVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -109,7 +109,7 @@ impl Vocab for PegasusVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<PegasusVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<PegasusVocab, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 
         let mut values = HashMap::new();
@@ -202,9 +202,9 @@ impl Vocab for PegasusVocab {
         })
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -104,7 +104,7 @@ impl Vocab for ProphetNetVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<ProphetNetVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<ProphetNetVocab, TokenizerError> {
         let values = read_flat_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -121,9 +121,9 @@ impl Vocab for ProphetNetVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -15,6 +15,7 @@ use crate::vocab::base_vocab::{
     read_flat_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// # ProphetNet Vocab
 /// Vocabulary for ProphetNet tokenizer. Contains the following special values:
@@ -103,7 +104,7 @@ impl Vocab for ProphetNetVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<ProphetNetVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<ProphetNetVocab, TokenizerError> {
         let values = read_flat_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -121,8 +122,8 @@ impl Vocab for ProphetNetVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
@@ -248,7 +249,7 @@ mod tests {
         .collect();
 
         //        When
-        let base_vocab = ProphetNetVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let base_vocab = ProphetNetVocab::from_file(&path)?;
 
         //        Then
         assert_eq!(base_vocab.get_unknown_value(), "[UNK]");
@@ -267,7 +268,7 @@ mod tests {
         let path = vocab_file.into_temp_path();
 
         //        When & Then
-        let _base_vocab = ProphetNetVocab::from_file(path.to_path_buf().to_str().unwrap()).unwrap();
+        let _base_vocab = ProphetNetVocab::from_file(&path).unwrap();
     }
 
     #[test]
@@ -279,7 +280,7 @@ mod tests {
             "hello \n world \n [UNK] \n ! \n [X_SEP] \n [SEP] \n [MASK] \n [PAD] \n [CLS]"
         )?;
         let path = vocab_file.into_temp_path();
-        let base_vocab = ProphetNetVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let base_vocab = ProphetNetVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(base_vocab.token_to_id("hello"), 0);
@@ -306,7 +307,7 @@ mod tests {
             "hello \n world \n [UNK] \n ! \n [X_SEP] \n [SEP] \n [MASK] \n [PAD] \n [CLS]"
         )?;
         let path = vocab_file.into_temp_path();
-        let bert_vocab = ProphetNetVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let bert_vocab = ProphetNetVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(bert_vocab.id_to_token(&(0_i64)), "hello");

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -77,7 +77,7 @@ impl Vocab for ReformerVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<ReformerVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<ReformerVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -93,9 +93,9 @@ impl Vocab for ReformerVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -17,6 +17,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # ReformerVocab
 /// Vocabulary for reformer tokenizer. Contains the following special values:
@@ -76,7 +77,7 @@ impl Vocab for ReformerVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<ReformerVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<ReformerVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -93,8 +94,8 @@ impl Vocab for ReformerVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -122,7 +122,7 @@ impl Vocab for RobertaVocab {
     }
 
     ///Read a Roberta-style vocab.json file
-    fn from_file(path: &Path) -> Result<RobertaVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<RobertaVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -138,9 +138,9 @@ impl Vocab for RobertaVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
     read_json_file, read_special_token_mapping_file, swap_key_values, SpecialTokenMap, Vocab,
 };
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # RoBERTa Vocab
 /// Vocabulary for RoBERTa tokenizer. Contains the following special values:
@@ -121,7 +122,7 @@ impl Vocab for RobertaVocab {
     }
 
     ///Read a Roberta-style vocab.json file
-    fn from_file(path: &str) -> Result<RobertaVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<RobertaVocab, TokenizerError> {
         let values = read_json_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -138,8 +139,8 @@ impl Vocab for RobertaVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_json_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;
@@ -264,7 +265,7 @@ mod tests {
         .collect();
 
         //        When
-        let roberta_vocab = RobertaVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let roberta_vocab = RobertaVocab::from_file(&path)?;
 
         //        Then
         assert_eq!(roberta_vocab.get_unknown_value(), "<unk>");
@@ -283,7 +284,7 @@ mod tests {
         let path = vocab_file.into_temp_path();
 
         //        When & Then
-        let _roberta_vocab = RobertaVocab::from_file(path.to_path_buf().to_str().unwrap()).unwrap();
+        let _roberta_vocab = RobertaVocab::from_file(&path).unwrap();
     }
 
     #[test]
@@ -292,7 +293,7 @@ mod tests {
         let mut vocab_file = tempfile::NamedTempFile::new()?;
         write!(vocab_file, "{{\"hello\": 1,\n \"world\": 0,\n \"<unk>\": 2,\n \"!\": 3\n, \"<pad>\": 4\n, \"<s>\": 5\n, \"</s>\": 6\n, \"<mask>\": 7\n}}")?;
         let path = vocab_file.into_temp_path();
-        let roberta_vocab = RobertaVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let roberta_vocab = RobertaVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(roberta_vocab.token_to_id("hello"), 1);
@@ -314,7 +315,7 @@ mod tests {
         let mut vocab_file = tempfile::NamedTempFile::new()?;
         write!(vocab_file, "{{\"hello\": 1,\n \"world\": 0,\n \"<unk>\": 2,\n \"!\": 3\n, \"<pad>\": 4\n, \"<s>\": 5\n, \"</s>\": 6\n, \"<mask>\": 7\n}}")?;
         let path = vocab_file.into_temp_path();
-        let roberta_vocab = RobertaVocab::from_file(path.to_path_buf().to_str().unwrap())?;
+        let roberta_vocab = RobertaVocab::from_file(&path)?;
 
         //        When & Then
         assert_eq!(roberta_vocab.id_to_token(&(1_i64)), "hello");

--- a/main/src/vocab/sentence_piece_bpe_model.rs
+++ b/main/src/vocab/sentence_piece_bpe_model.rs
@@ -45,9 +45,9 @@ impl SentencePieceBpeModel {
     /// # Example
     /// ```no_run
     /// use rust_tokenizers::vocab::SentencePieceBpeModel;
-    /// let path = "path/to/spiece.model";
     ///
-    /// let sentence_piece_model = SentencePieceBpeModel::from_file(&std::path::Path::new(path));
+    /// let path = std::path::Path::new("path/to/spiece.model");
+    /// let sentence_piece_model = SentencePieceBpeModel::from_file(&path);
     /// ```
     pub fn from_file(path: &Path) -> Result<SentencePieceBpeModel, TokenizerError> {
         let mut f = File::open(path).map_err(|e| {

--- a/main/src/vocab/sentence_piece_bpe_model.rs
+++ b/main/src/vocab/sentence_piece_bpe_model.rs
@@ -23,6 +23,7 @@ use std::collections::BinaryHeap;
 use std::fs::File;
 use std::io::Read;
 use std::ops::Index;
+use std::path::Path;
 
 #[derive(Debug, Clone)]
 pub struct BpeMergeVocab {
@@ -46,11 +47,15 @@ impl SentencePieceBpeModel {
     /// use rust_tokenizers::vocab::SentencePieceBpeModel;
     /// let path = "path/to/spiece.model";
     ///
-    /// let sentence_piece_model = SentencePieceBpeModel::from_file(path);
+    /// let sentence_piece_model = SentencePieceBpeModel::from_file(&std::path::Path::new(path));
     /// ```
-    pub fn from_file(path: &str) -> Result<SentencePieceBpeModel, TokenizerError> {
+    pub fn from_file(path: &Path) -> Result<SentencePieceBpeModel, TokenizerError> {
         let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+            TokenizerError::FileNotFound(format!(
+                "{} vocabulary file not found :{}",
+                path.display(),
+                e
+            ))
         })?;
         let mut contents = Vec::new();
         let proto = match f.read_to_end(&mut contents) {
@@ -82,7 +87,7 @@ impl SentencePieceBpeModel {
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
     ///
-    /// let sentence_piece_bpe_model = SentencePieceBpeModel::from_file(path).unwrap();
+    /// let sentence_piece_bpe_model = SentencePieceBpeModel::from_file(&std::path::Path::new(path)).unwrap();
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let tokenized_output = sentence_piece_bpe_model.tokenize_to_tokens(token);
     /// ```
@@ -191,7 +196,7 @@ impl SentencePieceBpeModel {
     /// use rust_tokenizers::vocab::SentencePieceBpeModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceBpeModel::from_file(path).unwrap();
+    /// let sentence_piece_model = SentencePieceBpeModel::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let mut sub_tokens = sentence_piece_model.tokenize_to_tokens(token);

--- a/main/src/vocab/sentence_piece_bpe_model.rs
+++ b/main/src/vocab/sentence_piece_bpe_model.rs
@@ -49,11 +49,11 @@ impl SentencePieceBpeModel {
     /// let path = std::path::Path::new("path/to/spiece.model");
     /// let sentence_piece_model = SentencePieceBpeModel::from_file(&path);
     /// ```
-    pub fn from_file(path: &Path) -> Result<SentencePieceBpeModel, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<SentencePieceBpeModel, TokenizerError> {
+        let mut f = File::open(&path).map_err(|e| {
             TokenizerError::FileNotFound(format!(
                 "{} vocabulary file not found :{}",
-                path.display(),
+                path.as_ref().display(),
                 e
             ))
         })?;

--- a/main/src/vocab/sentence_piece_bpe_model.rs
+++ b/main/src/vocab/sentence_piece_bpe_model.rs
@@ -45,9 +45,9 @@ impl SentencePieceBpeModel {
     /// # Example
     /// ```no_run
     /// use rust_tokenizers::vocab::SentencePieceBpeModel;
+    /// let path = "path/to/spiece.model";
     ///
-    /// let path = std::path::Path::new("path/to/spiece.model");
-    /// let sentence_piece_model = SentencePieceBpeModel::from_file(&path);
+    /// let sentence_piece_model = SentencePieceBpeModel::from_file(path);
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<SentencePieceBpeModel, TokenizerError> {
         let mut f = File::open(&path).map_err(|e| {
@@ -87,7 +87,7 @@ impl SentencePieceBpeModel {
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
     ///
-    /// let sentence_piece_bpe_model = SentencePieceBpeModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_bpe_model = SentencePieceBpeModel::from_file(path).unwrap();
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let tokenized_output = sentence_piece_bpe_model.tokenize_to_tokens(token);
     /// ```
@@ -196,7 +196,7 @@ impl SentencePieceBpeModel {
     /// use rust_tokenizers::vocab::SentencePieceBpeModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceBpeModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_model = SentencePieceBpeModel::from_file(path).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let mut sub_tokens = sentence_piece_model.tokenize_to_tokens(token);

--- a/main/src/vocab/sentence_piece_unigram_model.rs
+++ b/main/src/vocab/sentence_piece_unigram_model.rs
@@ -73,9 +73,9 @@ impl SentencePieceModel {
     /// # Example
     /// ```no_run
     /// use rust_tokenizers::vocab::SentencePieceModel;
-    /// let path = "path/to/spiece.model";
     ///
-    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let path = std::path::Path::new("path/to/spiece.model");
+    /// let sentence_piece_model = SentencePieceModel::from_file(&path).unwrap();
     /// ```
     pub fn from_file(path: &Path) -> Result<SentencePieceModel, TokenizerError> {
         let mut f = File::open(path).map_err(|e| {

--- a/main/src/vocab/sentence_piece_unigram_model.rs
+++ b/main/src/vocab/sentence_piece_unigram_model.rs
@@ -77,11 +77,11 @@ impl SentencePieceModel {
     /// let path = std::path::Path::new("path/to/spiece.model");
     /// let sentence_piece_model = SentencePieceModel::from_file(&path).unwrap();
     /// ```
-    pub fn from_file(path: &Path) -> Result<SentencePieceModel, TokenizerError> {
-        let mut f = File::open(path).map_err(|e| {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<SentencePieceModel, TokenizerError> {
+        let mut f = File::open(&path).map_err(|e| {
             TokenizerError::FileNotFound(format!(
                 "{} vocabulary file not found :{}",
-                path.display(),
+                path.as_ref().display(),
                 e
             ))
         })?;

--- a/main/src/vocab/sentence_piece_unigram_model.rs
+++ b/main/src/vocab/sentence_piece_unigram_model.rs
@@ -137,7 +137,7 @@ impl SentencePieceModel {
     /// ```no_run
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
     ///
     /// let query = "hello";
     /// let common_prefixes = sentence_piece_model.common_prefix_search(query);
@@ -186,7 +186,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);
@@ -244,7 +244,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);
@@ -282,7 +282,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);
@@ -335,7 +335,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);

--- a/main/src/vocab/sentence_piece_unigram_model.rs
+++ b/main/src/vocab/sentence_piece_unigram_model.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use protobuf::Message;
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Node<'a> {
@@ -74,11 +75,15 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// let path = "path/to/spiece.model";
     ///
-    /// let sentence_piece_model = SentencePieceModel::from_file(path);
+    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
     /// ```
-    pub fn from_file(path: &str) -> Result<SentencePieceModel, TokenizerError> {
+    pub fn from_file(path: &Path) -> Result<SentencePieceModel, TokenizerError> {
         let mut f = File::open(path).map_err(|e| {
-            TokenizerError::FileNotFound(format!("{} vocabulary file not found :{}", path, e))
+            TokenizerError::FileNotFound(format!(
+                "{} vocabulary file not found :{}",
+                path.display(),
+                e
+            ))
         })?;
         let mut contents = Vec::new();
         let proto = match f.read_to_end(&mut contents) {
@@ -132,7 +137,7 @@ impl SentencePieceModel {
     /// ```no_run
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let query = "hello";
     /// let common_prefixes = sentence_piece_model.common_prefix_search(query);
@@ -181,7 +186,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);
@@ -239,7 +244,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);
@@ -277,7 +282,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);
@@ -330,7 +335,7 @@ impl SentencePieceModel {
     /// use rust_tokenizers::vocab::SentencePieceModel;
     /// use rust_tokenizers::TokenRef;
     /// let path = "path/to/spiece.model";
-    /// let sentence_piece_model = SentencePieceModel::from_file(path).unwrap();
+    /// let sentence_piece_model = SentencePieceModel::from_file(&std::path::Path::new(path)).unwrap();
     ///
     /// let token = TokenRef::new("hello", &[0, 1, 2, 3]);
     /// let lattice_nodes = sentence_piece_model.decode_forward_token_ref(token);

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -65,7 +65,7 @@ impl Vocab for SentencePieceVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<SentencePieceVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<SentencePieceVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -81,9 +81,9 @@ impl Vocab for SentencePieceVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # SentencePieceVocab
 /// Vocabulary for SentencePiece model/tokenizer.
@@ -64,7 +65,7 @@ impl Vocab for SentencePieceVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<SentencePieceVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<SentencePieceVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -81,8 +82,8 @@ impl Vocab for SentencePieceVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # T5 Vocab
 /// Vocabulary for T5 tokenizer. Contains the following special values:
@@ -84,7 +85,7 @@ impl Vocab for T5Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<T5Vocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<T5Vocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -101,8 +102,8 @@ impl Vocab for T5Vocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -85,7 +85,7 @@ impl Vocab for T5Vocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<T5Vocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<T5Vocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -101,9 +101,9 @@ impl Vocab for T5Vocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -18,6 +18,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// # XLMRoBERTa Vocab
 /// Vocabulary for XLMRoBERTa tokenizer. Contains the following special values:
@@ -123,7 +124,7 @@ impl Vocab for XLMRobertaVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<XLMRobertaVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<XLMRobertaVocab, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -200,8 +201,8 @@ impl Vocab for XLMRobertaVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -124,7 +124,7 @@ impl Vocab for XLMRobertaVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<XLMRobertaVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<XLMRobertaVocab, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -200,9 +200,9 @@ impl Vocab for XLMRobertaVocab {
         })
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -126,7 +126,7 @@ impl Vocab for XLNetVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &Path) -> Result<XLNetVocab, TokenizerError> {
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<XLNetVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -145,9 +145,9 @@ impl Vocab for XLNetVocab {
         Self::from_values_and_special_token_map(values, special_token_map)
     }
 
-    fn from_file_with_special_token_mapping(
-        path: &Path,
-        special_token_mapping_path: &Path,
+    fn from_file_with_special_token_mapping<P: AsRef<Path>, S: AsRef<Path>>(
+        path: P,
+        special_token_mapping_path: S,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -16,6 +16,7 @@ use crate::vocab::base_vocab::{
 };
 use crate::vocab::Vocab;
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// # XLNet Vocab
 /// Vocabulary for XLNet tokenizer. Contains the following special values:
@@ -125,7 +126,7 @@ impl Vocab for XLNetVocab {
         &self.special_indices
     }
 
-    fn from_file(path: &str) -> Result<XLNetVocab, TokenizerError> {
+    fn from_file(path: &Path) -> Result<XLNetVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 
         let special_token_map = SpecialTokenMap {
@@ -145,8 +146,8 @@ impl Vocab for XLNetVocab {
     }
 
     fn from_file_with_special_token_mapping(
-        path: &str,
-        special_token_mapping_path: &str,
+        path: &Path,
+        special_token_mapping_path: &Path,
     ) -> Result<Self, TokenizerError> {
         let values = read_protobuf_file(path)?;
         let special_token_map = read_special_token_mapping_file(special_token_mapping_path)?;

--- a/main/tests/test_albert_uncased.rs
+++ b/main/tests/test_albert_uncased.rs
@@ -13,7 +13,7 @@ fn test_albert_tokenization() -> anyhow::Result<()> {
         "albert-base-v2-spiece.model",
     )?;
 
-    let albert_tokenizer = AlbertTokenizer::from_file(vocab_path.to_str().unwrap(), true, true)?;
+    let albert_tokenizer = AlbertTokenizer::from_file(&vocab_path, true, true)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_bert_uncased.rs
+++ b/main/tests/test_bert_uncased.rs
@@ -12,7 +12,7 @@ fn test_bert_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let vocab = BertVocab::from_file(vocab_path.to_str().unwrap())?;
+    let vocab = BertVocab::from_file(vocab_path.as_path())?;
     let bert_tokenizer: BertTokenizer = BertTokenizer::from_existing_vocab(vocab, true, true);
 
     let original_strings = [

--- a/main/tests/test_ctrl_cased.rs
+++ b/main/tests/test_ctrl_cased.rs
@@ -16,11 +16,7 @@ fn test_ctrl_tokenization() -> anyhow::Result<()> {
         "ctrl_merges.txt",
     )?;
 
-    let ctrl_tokenizer = CtrlTokenizer::from_file(
-        vocab_path.to_str().unwrap(),
-        merges_path.to_str().unwrap(),
-        false,
-    )?;
+    let ctrl_tokenizer = CtrlTokenizer::from_file(&vocab_path, &merges_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_deberta_cased.rs
+++ b/main/tests/test_deberta_cased.rs
@@ -18,11 +18,7 @@ fn test_deberta_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let deberta_tokenizer = DeBERTaTokenizer::from_file(
-        vocab_path.to_str().unwrap(),
-        merges_path.to_str().unwrap(),
-        false,
-    )?;
+    let deberta_tokenizer = DeBERTaTokenizer::from_file(&vocab_path, &merges_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_deberta_v2_cased.rs
+++ b/main/tests/test_deberta_v2_cased.rs
@@ -12,8 +12,7 @@ fn test_deberta_v2_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let deberta_v2_tokenizer =
-        DeBERTaV2Tokenizer::from_file(vocab_path.to_str().unwrap(), false, false, false)?;
+    let deberta_v2_tokenizer = DeBERTaV2Tokenizer::from_file(&vocab_path, false, false, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_fnet_cased.rs
+++ b/main/tests/test_fnet_cased.rs
@@ -13,7 +13,7 @@ fn test_fnet_tokenization() -> anyhow::Result<()> {
         "fnet-base-spiece.model",
     )?;
 
-    let fnet_tokenizer = FNetTokenizer::from_file(vocab_path.to_str().unwrap(), false, false)?;
+    let fnet_tokenizer = FNetTokenizer::from_file(&vocab_path, false, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_gpt2_cased.rs
+++ b/main/tests/test_gpt2_cased.rs
@@ -19,8 +19,8 @@ fn test_gpt2_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let vocab = Gpt2Vocab::from_file(vocab_path.to_str().unwrap())?;
-    let merges = BpePairVocab::from_file(merges_path.to_str().unwrap())?;
+    let vocab = Gpt2Vocab::from_file(vocab_path.as_path())?;
+    let merges = BpePairVocab::from_file(merges_path.as_path())?;
 
     let gpt2_tokenizer = Gpt2Tokenizer::from_existing_vocab_and_merges(vocab, merges, false);
 

--- a/main/tests/test_m2m100_cased.rs
+++ b/main/tests/test_m2m100_cased.rs
@@ -20,11 +20,7 @@ fn test_m2m100_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let mbart_tokenizer = M2M100Tokenizer::from_files(
-        vocab_path.to_str().unwrap(),
-        merges_path.to_str().unwrap(),
-        false,
-    )?;
+    let mbart_tokenizer = M2M100Tokenizer::from_files(&vocab_path, &merges_path, false)?;
 
     let original_strings = [
         ">>nl.<< …",

--- a/main/tests/test_mbart50_cased.rs
+++ b/main/tests/test_mbart50_cased.rs
@@ -13,7 +13,7 @@ fn test_mbart50_tokenization() -> anyhow::Result<()> {
         "mbart50_spiece.model",
     )?;
 
-    let mbart_tokenizer = MBart50Tokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let mbart_tokenizer = MBart50Tokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         ">>en<< …",

--- a/main/tests/test_openai_gpt_uncased.rs
+++ b/main/tests/test_openai_gpt_uncased.rs
@@ -18,11 +18,7 @@ fn test_openai_gpt_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let openai_gpt_tokenizer = OpenAiGptTokenizer::from_file(
-        vocab_path.to_str().unwrap(),
-        merges_path.to_str().unwrap(),
-        true,
-    )?;
+    let openai_gpt_tokenizer = OpenAiGptTokenizer::from_file(&vocab_path, &merges_path, true)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_pegasus_cased.rs
+++ b/main/tests/test_pegasus_cased.rs
@@ -13,7 +13,7 @@ fn test_pegasus_tokenization() -> anyhow::Result<()> {
         "pegasus-cnn_dailymail-spiece.model",
     )?;
 
-    let pegasus_tokenizer = PegasusTokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let pegasus_tokenizer = PegasusTokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_prophetnet_uncased.rs
+++ b/main/tests/test_prophetnet_uncased.rs
@@ -11,7 +11,7 @@ fn test_prophetnet_tokenization() -> anyhow::Result<()> {
         "prophetnet.tokenizer",
     )?;
 
-    let vocab = ProphetNetVocab::from_file(vocab_path.to_str().unwrap())?;
+    let vocab = ProphetNetVocab::from_file(&vocab_path)?;
     let bert_tokenizer: ProphetNetTokenizer =
         ProphetNetTokenizer::from_existing_vocab(vocab, true, true);
 

--- a/main/tests/test_reformer_cased.rs
+++ b/main/tests/test_reformer_cased.rs
@@ -11,8 +11,7 @@ fn test_reformer_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let bert_tokenizer: ReformerTokenizer =
-        ReformerTokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let bert_tokenizer: ReformerTokenizer = ReformerTokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_roberta_cased.rs
+++ b/main/tests/test_roberta_cased.rs
@@ -18,12 +18,7 @@ fn test_roberta_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let roberta_tokenizer = RobertaTokenizer::from_file(
-        vocab_path.to_str().unwrap(),
-        merges_path.to_str().unwrap(),
-        false,
-        true,
-    )?;
+    let roberta_tokenizer = RobertaTokenizer::from_file(&vocab_path, &merges_path, false, true)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_sentence_piece.rs
+++ b/main/tests/test_sentence_piece.rs
@@ -14,8 +14,7 @@ fn test_sentence_piece_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let sentence_piece_tokenizer =
-        SentencePieceTokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let sentence_piece_tokenizer = SentencePieceTokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_sentence_piece_bpe.rs
+++ b/main/tests/test_sentence_piece_bpe.rs
@@ -14,8 +14,7 @@ fn test_sentence_piece_bpe_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let mbart_tokenizer =
-        SentencePieceBpeTokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let mbart_tokenizer = SentencePieceBpeTokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_t5_cased.rs
+++ b/main/tests/test_t5_cased.rs
@@ -15,7 +15,7 @@ fn test_t5_tokenization() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let t5_tokenizer = T5Tokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let t5_tokenizer = T5Tokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_xlm_roberta_uncased.rs
+++ b/main/tests/test_xlm_roberta_uncased.rs
@@ -10,8 +10,7 @@ fn test_xlm_roberta_tokenization() -> anyhow::Result<()> {
     let vocab_path = download_file_to_cache("https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll03-english-sentencepiece.bpe.model",
                                             "xlm-roberta-spiece.model")?;
 
-    let xlm_roberta_tokenizer =
-        XLMRobertaTokenizer::from_file(vocab_path.to_str().unwrap(), false)?;
+    let xlm_roberta_tokenizer = XLMRobertaTokenizer::from_file(&vocab_path, false)?;
 
     let original_strings = [
         "…",

--- a/main/tests/test_xlnet_cased.rs
+++ b/main/tests/test_xlnet_cased.rs
@@ -12,7 +12,7 @@ fn test_xlnet_tokenization() -> anyhow::Result<()> {
         "xlnet-base-cased-spiece.model",
     )?;
 
-    let xlnet_tokenizer = XLNetTokenizer::from_file(vocab_path.to_str().unwrap(), false, true)?;
+    let xlnet_tokenizer = XLNetTokenizer::from_file(&vocab_path, false, true)?;
 
     let original_strings = [
         "…",

--- a/python-bindings/Cargo.lock
+++ b/python-bindings/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -302,11 +302,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -397,14 +397,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -425,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -445,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -499,18 +498,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -536,13 +535,13 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -561,18 +560,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -595,10 +594,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.19"
+name = "unicode-ident"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -611,12 +616,6 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "unindent"

--- a/python-bindings/src/lib.rs
+++ b/python-bindings/src/lib.rs
@@ -1011,9 +1011,7 @@ impl PyXLNetTokenizer {
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyMultiThreadTokenizer<XLNetTokenizer, XLNetVocab>>::tokenize_list(
-            self, text_list,
-        )
+        <Self as PyMultiThreadTokenizer<XLNetTokenizer, XLNetVocab>>::tokenize_list(self, text_list)
     }
 
     fn encode(

--- a/python-bindings/src/lib.rs
+++ b/python-bindings/src/lib.rs
@@ -818,7 +818,7 @@ impl PySentencePieceTokenizer {
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<SentencePieceTokenizer, SentencePieceVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -830,7 +830,7 @@ impl PySentencePieceTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<SentencePieceTokenizer, SentencePieceVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -847,7 +847,7 @@ impl PySentencePieceTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<SentencePieceTokenizer, SentencePieceVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -864,7 +864,7 @@ impl PySentencePieceTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<SentencePieceTokenizer, SentencePieceVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -879,7 +879,7 @@ impl PySentencePieceTokenizer {
         truncation_strategy: &str,
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
-        <Self as PyMultiThreadTokenizer<SentencePieceTokenizer, SentencePieceVocab>>::encode_pair_list(&self, text_list, max_len, truncation_strategy, stride)
+        <Self as PyMultiThreadTokenizer<SentencePieceTokenizer, SentencePieceVocab>>::encode_pair_list(self, text_list, max_len, truncation_strategy, stride)
     }
 }
 
@@ -924,7 +924,7 @@ impl PyAlbertTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<AlbertTokenizer, AlbertVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -941,7 +941,7 @@ impl PyAlbertTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<AlbertTokenizer, AlbertVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -958,7 +958,7 @@ impl PyAlbertTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<AlbertTokenizer, AlbertVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -974,7 +974,7 @@ impl PyAlbertTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<AlbertTokenizer, AlbertVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1007,12 +1007,12 @@ impl PyXLNetTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<XLNetTokenizer, XLNetVocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<XLNetTokenizer, XLNetVocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<XLNetTokenizer, XLNetVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1024,7 +1024,7 @@ impl PyXLNetTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<XLNetTokenizer, XLNetVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1041,7 +1041,7 @@ impl PyXLNetTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<XLNetTokenizer, XLNetVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1058,7 +1058,7 @@ impl PyXLNetTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<XLNetTokenizer, XLNetVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1074,7 +1074,7 @@ impl PyXLNetTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<XLNetTokenizer, XLNetVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1106,11 +1106,11 @@ impl PyT5Tokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<T5Tokenizer, T5Vocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<T5Tokenizer, T5Vocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyMultiThreadTokenizer<T5Tokenizer, T5Vocab>>::tokenize_list(&self, text_list)
+        <Self as PyMultiThreadTokenizer<T5Tokenizer, T5Vocab>>::tokenize_list(self, text_list)
     }
 
     fn encode(
@@ -1121,7 +1121,7 @@ impl PyT5Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<T5Tokenizer, T5Vocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1138,7 +1138,7 @@ impl PyT5Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<T5Tokenizer, T5Vocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1155,7 +1155,7 @@ impl PyT5Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<T5Tokenizer, T5Vocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1171,7 +1171,7 @@ impl PyT5Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<T5Tokenizer, T5Vocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1203,12 +1203,12 @@ impl PyXLMRobertaTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1220,7 +1220,7 @@ impl PyXLMRobertaTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1237,7 +1237,7 @@ impl PyXLMRobertaTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1254,7 +1254,7 @@ impl PyXLMRobertaTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1270,7 +1270,7 @@ impl PyXLMRobertaTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<XLMRobertaTokenizer, XLMRobertaVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1302,12 +1302,12 @@ impl PyReformerTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<ReformerTokenizer, ReformerVocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<ReformerTokenizer, ReformerVocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<ReformerTokenizer, ReformerVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1319,7 +1319,7 @@ impl PyReformerTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<ReformerTokenizer, ReformerVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1336,7 +1336,7 @@ impl PyReformerTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<ReformerTokenizer, ReformerVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1353,7 +1353,7 @@ impl PyReformerTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<ReformerTokenizer, ReformerVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1369,7 +1369,7 @@ impl PyReformerTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<ReformerTokenizer, ReformerVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1407,7 +1407,7 @@ impl PyProphetNetTokenizer {
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<ProphetNetTokenizer, ProphetNetVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1419,7 +1419,7 @@ impl PyProphetNetTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<ProphetNetTokenizer, ProphetNetVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1436,7 +1436,7 @@ impl PyProphetNetTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<ProphetNetTokenizer, ProphetNetVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1453,7 +1453,7 @@ impl PyProphetNetTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<ProphetNetTokenizer, ProphetNetVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1469,7 +1469,7 @@ impl PyProphetNetTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<ProphetNetTokenizer, ProphetNetVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1501,7 +1501,7 @@ impl PyPegasusTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<PegasusTokenizer, PegasusVocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<PegasusTokenizer, PegasusVocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
@@ -1518,7 +1518,7 @@ impl PyPegasusTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<PegasusTokenizer, PegasusVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1535,7 +1535,7 @@ impl PyPegasusTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<PegasusTokenizer, PegasusVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1552,7 +1552,7 @@ impl PyPegasusTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<PegasusTokenizer, PegasusVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1568,7 +1568,7 @@ impl PyPegasusTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<PegasusTokenizer, PegasusVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1600,12 +1600,12 @@ impl PyMBart50Tokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<MBart50Tokenizer, MBart50Vocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<MBart50Tokenizer, MBart50Vocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<MBart50Tokenizer, MBart50Vocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1617,7 +1617,7 @@ impl PyMBart50Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<MBart50Tokenizer, MBart50Vocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1634,7 +1634,7 @@ impl PyMBart50Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<MBart50Tokenizer, MBart50Vocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1651,7 +1651,7 @@ impl PyMBart50Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<MBart50Tokenizer, MBart50Vocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1667,7 +1667,7 @@ impl PyMBart50Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<MBart50Tokenizer, MBart50Vocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1707,7 +1707,7 @@ impl PySentencePieceBpeTokenizer {
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<SentencePieceBpeTokenizer, SentencePieceVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1719,7 +1719,7 @@ impl PySentencePieceBpeTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<SentencePieceBpeTokenizer, SentencePieceVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1736,7 +1736,7 @@ impl PySentencePieceBpeTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<SentencePieceBpeTokenizer, SentencePieceVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1753,7 +1753,7 @@ impl PySentencePieceBpeTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<SentencePieceBpeTokenizer, SentencePieceVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1769,7 +1769,7 @@ impl PySentencePieceBpeTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<SentencePieceBpeTokenizer, SentencePieceVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1811,7 +1811,7 @@ impl PyM2M100Tokenizer {
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<M2M100Tokenizer, M2M100Vocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -1823,7 +1823,7 @@ impl PyM2M100Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<M2M100Tokenizer, M2M100Vocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1840,7 +1840,7 @@ impl PyM2M100Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<M2M100Tokenizer, M2M100Vocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1857,7 +1857,7 @@ impl PyM2M100Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<M2M100Tokenizer, M2M100Vocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1873,7 +1873,7 @@ impl PyM2M100Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<M2M100Tokenizer, M2M100Vocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1906,11 +1906,11 @@ impl PyFNetTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<FNetTokenizer, FNetVocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<FNetTokenizer, FNetVocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
-        <Self as PyMultiThreadTokenizer<FNetTokenizer, FNetVocab>>::tokenize_list(&self, text_list)
+        <Self as PyMultiThreadTokenizer<FNetTokenizer, FNetVocab>>::tokenize_list(self, text_list)
     }
 
     fn encode(
@@ -1921,7 +1921,7 @@ impl PyFNetTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<FNetTokenizer, FNetVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -1938,7 +1938,7 @@ impl PyFNetTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<FNetTokenizer, FNetVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -1955,7 +1955,7 @@ impl PyFNetTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<FNetTokenizer, FNetVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -1971,7 +1971,7 @@ impl PyFNetTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<FNetTokenizer, FNetVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -2008,12 +2008,12 @@ impl PyDeBertaTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -2025,7 +2025,7 @@ impl PyDeBertaTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -2042,7 +2042,7 @@ impl PyDeBertaTokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -2059,7 +2059,7 @@ impl PyDeBertaTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -2075,7 +2075,7 @@ impl PyDeBertaTokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<DeBERTaTokenizer, DeBERTaVocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -2118,12 +2118,12 @@ impl PyDeBertaV2Tokenizer {
     }
 
     fn tokenize(&self, text: &str) -> PyResult<Vec<String>> {
-        <Self as PyTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::tokenize(&self, text)
+        <Self as PyTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::tokenize(self, text)
     }
 
     fn tokenize_list(&self, text_list: Vec<&str>) -> PyResult<Vec<Vec<String>>> {
         <Self as PyMultiThreadTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::tokenize_list(
-            &self, text_list,
+            self, text_list,
         )
     }
 
@@ -2135,7 +2135,7 @@ impl PyDeBertaV2Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::encode(
-            &self,
+            self,
             text,
             max_len,
             truncation_strategy,
@@ -2152,7 +2152,7 @@ impl PyDeBertaV2Tokenizer {
         stride: usize,
     ) -> PyResult<PyTokenizedInput> {
         <Self as PyTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::encode_pair(
-            &self,
+            self,
             text_a,
             text_b,
             max_len,
@@ -2169,7 +2169,7 @@ impl PyDeBertaV2Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::encode_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,
@@ -2185,7 +2185,7 @@ impl PyDeBertaV2Tokenizer {
         stride: usize,
     ) -> PyResult<Vec<PyTokenizedInput>> {
         <Self as PyMultiThreadTokenizer<DeBERTaV2Tokenizer, DeBERTaV2Vocab>>::encode_pair_list(
-            &self,
+            self,
             text_list,
             max_len,
             truncation_strategy,


### PR DESCRIPTION
Master PR: #76
Blocked by: #79

## Motivation

1. Not every FS path is a valid utf-8 string.
2. `AsRef<Path>` is strictly more acceptable with same level of correctness:
you can use `&str`, `Path` and `PathBuf`.

## Implementation

- [x] Use `AsRef<Path>` instead of `&str`.
- [x] Remove unnecessary type casts and unwraps from tests.

@veta666, this one is also on you.