### PR TITLE
Allow addition of tokens in vocab/tokenizer

### DIFF
--- a/main/Cargo.lock
+++ b/main/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "rust_tokenizers"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "cached-path",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_tokenizers"
-version = "8.0.0"
+version = "8.1.0"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 description = "High performance tokenizers for Rust"

--- a/main/src/tokenizer/albert_tokenizer.rs
+++ b/main/src/tokenizer/albert_tokenizer.rs
@@ -198,6 +198,9 @@ impl Tokenizer<AlbertVocab> for AlbertTokenizer {
     fn vocab(&self) -> &AlbertVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut AlbertVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(text, &self.vocab)

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -465,6 +465,9 @@ pub trait Tokenizer<T: Vocab> {
     /// returns a reference to the tokenizer vocabulary
     fn vocab(&self) -> &T;
 
+    /// returns a mutable reference to the tokenizer vocabulary
+    fn vocab_mut(&mut self) -> &mut T;
+
     /// Tokenize a string, returns a vector of tokens as strings.
     /// Use `tokenize_with_offsets` or `tokenize_to_tokens` to return offset information.
     ///
@@ -1201,7 +1204,7 @@ pub trait Tokenizer<T: Vocab> {
 /// # Extension for multithreaded tokenizers
 pub trait MultiThreadedTokenizer<T: Vocab>
 where
-    Self: std::marker::Sync + Send + Tokenizer<T>,
+    Self: Sync + Send + Tokenizer<T>,
 {
     /// returns a reference to the tokenizer vocabulary
     fn vocab(&self) -> &T {
@@ -1555,6 +1558,9 @@ impl<T: Vocab + Sync> BaseTokenizer<T> {
 impl<T: Vocab + Sync + Send> Tokenizer<T> for BaseTokenizer<T> {
     fn vocab(&self) -> &T {
         &self.vocab
+    }
+    fn vocab_mut(&mut self) -> &mut T {
+        &mut self.vocab
     }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {

--- a/main/src/tokenizer/base_tokenizer.rs
+++ b/main/src/tokenizer/base_tokenizer.rs
@@ -1199,6 +1199,28 @@ pub trait Tokenizer<T: Vocab> {
             mask: tokens_ids_with_offsets_1.masks,
         }
     }
+
+    /// Add arbitrary tokens to the vocabulary.
+    ///
+    /// These tokens are added to the special token map and are ignored from the tokenization
+    /// algorithm chosen (e.g.
+    ///
+    /// # Parameters
+    /// - tokens (`&[&str]`): list of tokens to add to the vocabulary
+    fn add_tokens(&mut self, tokens: &[&str]) {
+        self.vocab_mut().add_tokens(tokens);
+    }
+
+    /// Add arbitrary tokens to the vocabulary.
+    ///
+    /// These tokens are added to the special token map and are ignored from the tokenization
+    /// algorithm chosen (e.g.
+    ///
+    /// # Parameters
+    /// - num_extra_ids (`i64`): number of tokens to append
+    fn add_extra_ids(&mut self, num_extra_ids: i64) {
+        self.vocab_mut().add_extra_ids(num_extra_ids);
+    }
 }
 
 /// # Extension for multithreaded tokenizers

--- a/main/src/tokenizer/bert_tokenizer.rs
+++ b/main/src/tokenizer/bert_tokenizer.rs
@@ -137,6 +137,9 @@ impl Tokenizer<BertVocab> for BertTokenizer {
     fn vocab(&self) -> &BertVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut BertVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         //the base tokenizers does most of the work, we simply add a wordpiece tokenizer on top

--- a/main/src/tokenizer/ctrl_tokenizer.rs
+++ b/main/src/tokenizer/ctrl_tokenizer.rs
@@ -158,6 +158,9 @@ impl Tokenizer<OpenAiGptVocab> for CtrlTokenizer {
     fn vocab(&self) -> &OpenAiGptVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut OpenAiGptVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(initial_token, &self.vocab)

--- a/main/src/tokenizer/deberta_tokenizer.rs
+++ b/main/src/tokenizer/deberta_tokenizer.rs
@@ -175,6 +175,9 @@ impl Tokenizer<DeBERTaVocab> for DeBERTaTokenizer {
     fn vocab(&self) -> &DeBERTaVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut DeBERTaVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(initial_token, &self.vocab)

--- a/main/src/tokenizer/deberta_v2_tokenizer.rs
+++ b/main/src/tokenizer/deberta_v2_tokenizer.rs
@@ -223,6 +223,9 @@ impl Tokenizer<DeBERTaV2Vocab> for DeBERTaV2Tokenizer {
     fn vocab(&self) -> &DeBERTaV2Vocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut DeBERTaV2Vocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         let mut initial_token: Token = initial_token.to_owned();

--- a/main/src/tokenizer/fnet_tokenizer.rs
+++ b/main/src/tokenizer/fnet_tokenizer.rs
@@ -196,6 +196,9 @@ impl Tokenizer<FNetVocab> for FNetTokenizer {
     fn vocab(&self) -> &FNetVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut FNetVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(text, &self.vocab)

--- a/main/src/tokenizer/gpt2_tokenizer.rs
+++ b/main/src/tokenizer/gpt2_tokenizer.rs
@@ -174,6 +174,9 @@ impl Tokenizer<Gpt2Vocab> for Gpt2Tokenizer {
     fn vocab(&self) -> &Gpt2Vocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut Gpt2Vocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(initial_token, &self.vocab)

--- a/main/src/tokenizer/m2m100_tokenizer.rs
+++ b/main/src/tokenizer/m2m100_tokenizer.rs
@@ -148,6 +148,9 @@ impl Tokenizer<M2M100Vocab> for M2M100Tokenizer {
     fn vocab(&self) -> &M2M100Vocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut M2M100Vocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let tokens = split_on_language_code(text, 7, &self.vocab.language_codes_bytes);

--- a/main/src/tokenizer/marian_tokenizer.rs
+++ b/main/src/tokenizer/marian_tokenizer.rs
@@ -151,6 +151,9 @@ impl Tokenizer<MarianVocab> for MarianTokenizer {
     fn vocab(&self) -> &MarianVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut MarianVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let tokens = split_at_regex(text, &self.pattern_language_code);

--- a/main/src/tokenizer/mbart50_tokenizer.rs
+++ b/main/src/tokenizer/mbart50_tokenizer.rs
@@ -134,6 +134,9 @@ impl Tokenizer<MBart50Vocab> for MBart50Tokenizer {
     fn vocab(&self) -> &MBart50Vocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut MBart50Vocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let tokens = split_on_language_code(text, 6, &self.vocab.language_codes_bytes);

--- a/main/src/tokenizer/nllb_tokenizer.rs
+++ b/main/src/tokenizer/nllb_tokenizer.rs
@@ -77,6 +77,9 @@ impl Tokenizer<NLLBVocab> for NLLBTokenizer {
     fn vocab(&self) -> &NLLBVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut NLLBVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: crate::TokenRef) -> Vec<crate::Token> {
         let tokens = split_on_language_code(text, 8, &self.vocab.language_codes_bytes);

--- a/main/src/tokenizer/openai_gpt_tokenizer.rs
+++ b/main/src/tokenizer/openai_gpt_tokenizer.rs
@@ -149,6 +149,9 @@ impl Tokenizer<OpenAiGptVocab> for OpenAiGptTokenizer {
     fn vocab(&self) -> &OpenAiGptVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut OpenAiGptVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         let tokens: Vec<Token> = self

--- a/main/src/tokenizer/pegasus_tokenizer.rs
+++ b/main/src/tokenizer/pegasus_tokenizer.rs
@@ -131,6 +131,9 @@ impl Tokenizer<PegasusVocab> for PegasusTokenizer {
     fn vocab(&self) -> &PegasusVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut PegasusVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut token = text.to_owned();

--- a/main/src/tokenizer/prophetnet_tokenizer.rs
+++ b/main/src/tokenizer/prophetnet_tokenizer.rs
@@ -139,6 +139,9 @@ impl Tokenizer<ProphetNetVocab> for ProphetNetTokenizer {
     fn vocab(&self) -> &ProphetNetVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut ProphetNetVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         //the base tokenizers does most of the work, we simply add a wordpiece tokenizer on top

--- a/main/src/tokenizer/reformer_tokenizer.rs
+++ b/main/src/tokenizer/reformer_tokenizer.rs
@@ -106,6 +106,9 @@ impl Tokenizer<ReformerVocab> for ReformerTokenizer {
     fn vocab(&self) -> &ReformerVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut ReformerVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(text, &self.vocab)

--- a/main/src/tokenizer/roberta_tokenizer.rs
+++ b/main/src/tokenizer/roberta_tokenizer.rs
@@ -200,6 +200,9 @@ impl Tokenizer<RobertaVocab> for RobertaTokenizer {
     fn vocab(&self) -> &RobertaVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut RobertaVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, initial_token: TokenRef) -> Vec<Token> {
         if initial_token.text.is_empty() {

--- a/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_bpe_tokenizer.rs
@@ -135,6 +135,9 @@ impl Tokenizer<SentencePieceVocab> for SentencePieceBpeTokenizer {
     fn vocab(&self) -> &SentencePieceVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut SentencePieceVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut token = text.to_owned();

--- a/main/src/tokenizer/sentence_piece_tokenizer.rs
+++ b/main/src/tokenizer/sentence_piece_tokenizer.rs
@@ -133,6 +133,9 @@ impl Tokenizer<SentencePieceVocab> for SentencePieceTokenizer {
     fn vocab(&self) -> &SentencePieceVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut SentencePieceVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut token = text.to_owned();

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -145,6 +145,9 @@ impl Tokenizer<T5Vocab> for T5Tokenizer {
     fn vocab(&self) -> &T5Vocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut T5Vocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(text, &self.vocab)

--- a/main/src/tokenizer/t5_tokenizer.rs
+++ b/main/src/tokenizer/t5_tokenizer.rs
@@ -54,7 +54,8 @@ impl T5Tokenizer {
         lower_case: bool,
     ) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
-        let vocab = T5Vocab::from_file(path)?;
+        let mut vocab = T5Vocab::from_file(path)?;
+        vocab.add_extra_ids(100);
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
         Ok(T5Tokenizer {
             model,
@@ -89,8 +90,9 @@ impl T5Tokenizer {
         special_token_mapping_path: S,
     ) -> Result<T5Tokenizer, TokenizerError> {
         let model = SentencePieceModel::from_file(&path)?;
-        let vocab =
+        let mut vocab =
             T5Vocab::from_file_with_special_token_mapping(path, special_token_mapping_path)?;
+        vocab.add_extra_ids(100);
         let eos_token_id = vocab.token_to_id(vocab.get_eos_value());
         Ok(T5Tokenizer {
             model,

--- a/main/src/tokenizer/xlm_roberta_tokenizer.rs
+++ b/main/src/tokenizer/xlm_roberta_tokenizer.rs
@@ -136,6 +136,9 @@ impl Tokenizer<XLMRobertaVocab> for XLMRobertaTokenizer {
     fn vocab(&self) -> &XLMRobertaVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut XLMRobertaVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(text, &self.vocab)

--- a/main/src/tokenizer/xlnet_tokenizer.rs
+++ b/main/src/tokenizer/xlnet_tokenizer.rs
@@ -196,6 +196,9 @@ impl Tokenizer<XLNetVocab> for XLNetTokenizer {
     fn vocab(&self) -> &XLNetVocab {
         &self.vocab
     }
+    fn vocab_mut(&mut self) -> &mut XLNetVocab {
+        &mut self.vocab
+    }
 
     fn tokenize_to_tokens(&self, text: TokenRef) -> Vec<Token> {
         let mut tokens = split_on_special_tokens(text, &self.vocab)

--- a/main/src/vocab/albert_vocab.rs
+++ b/main/src/vocab/albert_vocab.rs
@@ -123,6 +123,22 @@ impl Vocab for AlbertVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<AlbertVocab, TokenizerError> {
         let values = read_protobuf_file(path.as_ref())?;
 

--- a/main/src/vocab/base_vocab.rs
+++ b/main/src/vocab/base_vocab.rs
@@ -357,10 +357,33 @@ pub trait Vocab {
         tokens.iter().map(|v| self.token_to_id(v)).collect()
     }
 
+    /// Add extra token ids to the vocab
+    ///
+    /// These tokens are generated automatically using the `<extra_id_{i}>` template and appended to
+    /// the vocabulary. These are ignored from the tokenization algorithm chosen (pre-tokenized).
+    /// This is used by some architectures to allow for further task-specific token identified
+    /// following the pre-training phase (e.g. T5 adds 100 of these tokens at creation).
+    ///
+    /// # Parameters
+    /// - num_extra_ids (`i64`): number of tokens to append
+    fn add_extra_ids(&mut self, num_extra_ids: i64) {
+        let mut additional_special_tokens: Vec<String> = Vec::with_capacity(num_extra_ids as usize);
+        for extra_id in 0..num_extra_ids {
+            additional_special_tokens.push(format!("<extra_id_{extra_id}>"));
+        }
+        self.add_tokens(
+            additional_special_tokens
+                .iter()
+                .map(AsRef::as_ref)
+                .collect::<Vec<&str>>()
+                .as_slice(),
+        );
+    }
+
     /// Add arbitrary tokens to the vocabulary.
     ///
     /// These tokens are added to the special token map and are ignored from the tokenization
-    /// algorithm chosen (e.g.
+    /// algorithm chosen (pre-tokenized).
     ///
     /// # Parameters
     /// - tokens (`&[&str]`): list of tokens to add to the vocabulary

--- a/main/src/vocab/bert_vocab.rs
+++ b/main/src/vocab/bert_vocab.rs
@@ -103,6 +103,22 @@ impl Vocab for BertVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<BertVocab, TokenizerError> {
         let values = read_flat_file(path)?;
         let special_token_map = SpecialTokenMap {

--- a/main/src/vocab/deberta_v2_vocab.rs
+++ b/main/src/vocab/deberta_v2_vocab.rs
@@ -122,6 +122,22 @@ impl Vocab for DeBERTaV2Vocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<DeBERTaV2Vocab, TokenizerError> {
         let mut values = read_protobuf_file(path)?;
 

--- a/main/src/vocab/deberta_vocab.rs
+++ b/main/src/vocab/deberta_vocab.rs
@@ -122,6 +122,22 @@ impl Vocab for DeBERTaVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<DeBERTaVocab, TokenizerError> {
         let values = read_json_file(path)?;
 

--- a/main/src/vocab/fnet_vocab.rs
+++ b/main/src/vocab/fnet_vocab.rs
@@ -105,6 +105,22 @@ impl Vocab for FNetVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<FNetVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 

--- a/main/src/vocab/gpt2_vocab.rs
+++ b/main/src/vocab/gpt2_vocab.rs
@@ -85,6 +85,22 @@ impl Vocab for Gpt2Vocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<Gpt2Vocab, TokenizerError> {
         let values = read_json_file(path)?;
 

--- a/main/src/vocab/m2m100_vocab.rs
+++ b/main/src/vocab/m2m100_vocab.rs
@@ -118,6 +118,22 @@ impl Vocab for M2M100Vocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<M2M100Vocab, TokenizerError> {
         let values = read_json_file(path)?;
 

--- a/main/src/vocab/marian_vocab.rs
+++ b/main/src/vocab/marian_vocab.rs
@@ -87,6 +87,22 @@ impl Vocab for MarianVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<MarianVocab, TokenizerError> {
         let values = read_json_file(path)?;
 

--- a/main/src/vocab/mbart50_vocab.rs
+++ b/main/src/vocab/mbart50_vocab.rs
@@ -126,6 +126,22 @@ impl Vocab for MBart50Vocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<MBart50Vocab, TokenizerError> {
         let mut values = HashMap::new();
         let mut special_values = HashMap::new();

--- a/main/src/vocab/nllb_vocab.rs
+++ b/main/src/vocab/nllb_vocab.rs
@@ -182,6 +182,22 @@ impl Vocab for NLLBVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, TokenizerError> {
         let values = Tokenizer::deserialize(path)?.model.vocab;
 

--- a/main/src/vocab/openai_gpt_vocab.rs
+++ b/main/src/vocab/openai_gpt_vocab.rs
@@ -64,6 +64,22 @@ impl Vocab for OpenAiGptVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<OpenAiGptVocab, TokenizerError> {
         let values = read_json_file(path)?;
 

--- a/main/src/vocab/pegasus_vocab.rs
+++ b/main/src/vocab/pegasus_vocab.rs
@@ -109,6 +109,22 @@ impl Vocab for PegasusVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<PegasusVocab, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 

--- a/main/src/vocab/prophetnet_vocab.rs
+++ b/main/src/vocab/prophetnet_vocab.rs
@@ -104,6 +104,22 @@ impl Vocab for ProphetNetVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<ProphetNetVocab, TokenizerError> {
         let values = read_flat_file(path)?;
 

--- a/main/src/vocab/reformer_vocab.rs
+++ b/main/src/vocab/reformer_vocab.rs
@@ -77,6 +77,22 @@ impl Vocab for ReformerVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<ReformerVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 

--- a/main/src/vocab/roberta_vocab.rs
+++ b/main/src/vocab/roberta_vocab.rs
@@ -121,6 +121,22 @@ impl Vocab for RobertaVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     ///Read a Roberta-style vocab.json file
     fn from_file<P: AsRef<Path>>(path: P) -> Result<RobertaVocab, TokenizerError> {
         let values = read_json_file(path)?;

--- a/main/src/vocab/sentence_piece_vocab.rs
+++ b/main/src/vocab/sentence_piece_vocab.rs
@@ -65,6 +65,22 @@ impl Vocab for SentencePieceVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<SentencePieceVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 

--- a/main/src/vocab/t5_vocab.rs
+++ b/main/src/vocab/t5_vocab.rs
@@ -85,6 +85,22 @@ impl Vocab for T5Vocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<T5Vocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 

--- a/main/src/vocab/xlm_roberta_vocab.rs
+++ b/main/src/vocab/xlm_roberta_vocab.rs
@@ -124,6 +124,22 @@ impl Vocab for XLMRobertaVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<XLMRobertaVocab, TokenizerError> {
         let proto = open_protobuf_file(path)?;
 

--- a/main/src/vocab/xlnet_vocab.rs
+++ b/main/src/vocab/xlnet_vocab.rs
@@ -126,6 +126,22 @@ impl Vocab for XLNetVocab {
         &self.special_indices
     }
 
+    fn values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.values
+    }
+
+    fn indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.indices
+    }
+
+    fn special_values_mut(&mut self) -> &mut HashMap<String, i64> {
+        &mut self.special_values
+    }
+
+    fn special_indices_mut(&mut self) -> &mut HashMap<i64, String> {
+        &mut self.special_indices
+    }
+
     fn from_file<P: AsRef<Path>>(path: P) -> Result<XLNetVocab, TokenizerError> {
         let values = read_protobuf_file(path)?;
 

--- a/main/tests/test_t5_cased.rs
+++ b/main/tests/test_t5_cased.rs
@@ -9,17 +9,16 @@ use test_utils::download_file_to_cache;
 
 #[test]
 fn test_t5_tokenization() -> anyhow::Result<()> {
-    let vocab_path = download_file_to_cache(
-        "https://s3.amazonaws.com/models.huggingface.co/bert/t5-spiece.model",
-    )
-    .unwrap();
+    let vocab_path =
+        download_file_to_cache("https://huggingface.co/t5-base/resolve/main/spiece.model").unwrap();
 
-    let t5_tokenizer = T5Tokenizer::from_file(vocab_path, false)?;
+    let mut t5_tokenizer = T5Tokenizer::from_file(vocab_path, false)?;
+    t5_tokenizer.add_tokens(&["<sep>", "<hl>"]);
 
     let original_strings = [
         "…",
         "This is a sample sentence to be tokénized",
-        "Wondering how this will get tokenized 🤔 ?",
+        "Wondering how this <sep> will get <hl> tokenized 🤔 ?",
         "İs th!s 𩸽 Ϻ Šœ Ugljšić dấu nặng",
         "   İs th!s    𩸽 Ϻ Šœ   Ugljšić  dấu nặng     ",
         " � İs th!s �� 𩸽 Ϻ Šœ   Ugljšić  dấu nặng     ",
@@ -66,7 +65,9 @@ fn test_t5_tokenization() -> anyhow::Result<()> {
             mask: vec![],
         },
         TokenizedInput {
-            token_ids: vec![16347, 53, 149, 48, 56, 129, 14145, 1601, 3, 2, 3, 58, 1],
+            token_ids: vec![
+                16347, 53, 149, 48, 32100, 56, 129, 32101, 14145, 1601, 3, 2, 3, 58, 1,
+            ],
             segment_ids: vec![],
             special_tokens_mask: vec![],
             overflowing_tokens: vec![],
@@ -76,14 +77,16 @@ fn test_t5_tokenization() -> anyhow::Result<()> {
                 Some(Offset { begin: 6, end: 9 }),
                 Some(Offset { begin: 9, end: 13 }),
                 Some(Offset { begin: 13, end: 18 }),
-                Some(Offset { begin: 18, end: 23 }),
-                Some(Offset { begin: 23, end: 27 }),
-                Some(Offset { begin: 27, end: 33 }),
-                Some(Offset { begin: 33, end: 37 }),
-                Some(Offset { begin: 37, end: 38 }),
-                Some(Offset { begin: 38, end: 39 }),
-                Some(Offset { begin: 39, end: 40 }),
-                Some(Offset { begin: 40, end: 41 }),
+                Some(Offset { begin: 19, end: 24 }),
+                Some(Offset { begin: 24, end: 29 }),
+                Some(Offset { begin: 29, end: 33 }),
+                Some(Offset { begin: 34, end: 38 }),
+                Some(Offset { begin: 38, end: 44 }),
+                Some(Offset { begin: 44, end: 48 }),
+                Some(Offset { begin: 48, end: 49 }),
+                Some(Offset { begin: 49, end: 50 }),
+                Some(Offset { begin: 50, end: 51 }),
+                Some(Offset { begin: 51, end: 52 }),
                 None,
             ],
             reference_offsets: vec![],

--- a/python-bindings/Cargo.toml
+++ b/python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_tokenizers_python"
-version = "8.0.0-alpha"
+version = "8.1.0"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 description = "High performance tokenizers for Rust"

--- a/python-bindings/setup.py
+++ b/python-bindings/setup.py
@@ -67,7 +67,7 @@ test_requires = ["pytest", "pytest-benchmark", "torch>=1.11.0", "transformers==4
 
 setup(
     name="rust_tokenizers",
-    version="8.0.0",
+    version="8.1.0",
     packages=["rust_tokenizers"],
     rust_extensions=[RustExtension("rust_tokenizers.rust_tokenizers", "Cargo.toml", debug=False)],
     setup_requires=setup_requires,


### PR DESCRIPTION
- Addition of `add_extra_ids` method to allow appending automatically formatted special tokens at the end of the vocab (used by T5)
- Addition of `add_tokens` method to allow adding arbitrary tokens to a vocabulary (these are handled as special tokens and pre-tokenized before the tokenization algorithm)
- Addition of mutable getter methods for the vocab and special values vocab

Relates to https://github.com/guillaume-be/rust-bert/issues/343